### PR TITLE
Updates to support Python 3 + small (yet important) updates to README

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+*.pyc
 *.egg-info/
 .virtualenv*/
 .venv*/

--- a/README.md
+++ b/README.md
@@ -92,7 +92,8 @@ Will add an example file here in the near future.
 ### Use as a package
 
 ```python
-> import dedoppler_bones
+> import turbo_seti
+> from turbo_seti.findoppler.findopp import FinDoppler
 ```
 
 **BL internal**:
@@ -101,10 +102,10 @@ Currently, there is some voyager test data in bls0 at the GBT cluster.
 From the .../turbo_seti/bin/ folder run the next command.
 
 ```bash
-$ python seti_event.py /datax/eenriquez/voyager_test/blc07_guppi_57650_67573_Voyager1_0002.gpuspec.0000.fil -p <your_test_folder> -M 2
+$ python seti_event.py /datax/users/eenriquez/voyager_test/blc07_guppi_57650_67573_Voyager1_0002.gpuspec.0000.fil -o <your_test_folder> -M 2
 ```
 
-This will take `/datax/eenriquez/voyager_test/test_dedop_bones/blc07_guppi_57650_67573_Voyager1_0002.gpuspec.0000.fil` as input (and in this particular case it will discover that this file is too big to handle all at once, so it will first partition it into smaller FITS files and save them into the directory specified by option **`-p`**, and then proceed with drift signal search for each small FITS files). Everything else was set to default values.
+This will take `/datax/users/eenriquez/voyager_test/blc07_guppi_57650_67573_Voyager1_0002.gpuspec.0000.fil` as input (and in this particular case it will discover that this file is too big to handle all at once, so it will first partition it into smaller FITS files and save them into the directory specified by option **`-o`**, and then proceed with drift signal search for each small FITS files). Everything else was set to default values.
 
 Sample Outputs:
 See `/datax/eenriquez/voyager_test/*/*.log`, `/datax/eenriquez/voyager_test/*.dat` for search results and see `/datax/eenriquez/voyager_test/*.png` for some plots.

--- a/turbo_seti/__init__.py
+++ b/turbo_seti/__init__.py
@@ -1,2 +1,2 @@
-from .findoppler import seti_event, find_candidates, plot_candidates
-
+# from findoppler import seti_event, find_candidates, plot_candidates
+import *

--- a/turbo_seti/__init__.py
+++ b/turbo_seti/__init__.py
@@ -1,4 +1,4 @@
 try:
     from .findoppler import seti_event, find_candidates, plot_candidates
 except:
-    import *
+    from findoppler import seti_event, find_candidates, plot_candidates

--- a/turbo_seti/findoppler/__init__.py
+++ b/turbo_seti/findoppler/__init__.py
@@ -1,1 +1,1 @@
-from . import *
+import *

--- a/turbo_seti/findoppler/__init__.py
+++ b/turbo_seti/findoppler/__init__.py
@@ -1,4 +1,1 @@
-try:
-    from . import *
-except:
-    import *
+from . import *

--- a/turbo_seti/findoppler/data_handler.py
+++ b/turbo_seti/findoppler/data_handler.py
@@ -150,7 +150,7 @@ class DATAH5:
             else:
                 header = self.__make_data_header(self.fil_file.header)
         except:
-            logger.debug('The fil_file.header is ' % header)
+            logger.debug('The fil_file.header is ' % self.fil_file.header)
             raise IOError("Error accessing header from file: %s." % self.filename)
 
         self.header = header
@@ -225,7 +225,7 @@ class DATAH5:
         di_array = np.genfromtxt(resource_filename('turbo_seti', 'drift_indexes/drift_indexes_array_%d.txt'%n), delimiter=' ', dtype=int)
 
         ts2 = int(self.tsteps/2)
-        drift_indexes = di_array[0:(self.tsteps_valid - 1 - ts2), 0:self.tsteps_valid]
+        drift_indexes = di_array[(self.tsteps_valid - 1 - ts2), 0:self.tsteps_valid]
         return drift_indexes
 
     def __make_data_header(self,header,coarse=False):
@@ -268,7 +268,7 @@ class DATAH5:
                 base_header[b'FCNTR'] = (self.f_stop - self.f_start)/2. + self.f_start
             else:
                 base_header[b'NAXIS1'] = int(header[b'nchans'])
-                base_header[b'FCNTR'] = float(header[b'fch1']) + header[b'foff']*base_header[b'naxis1']/2
+                base_header[b'FCNTR'] = float(header[b'fch1']) + header[b'foff']*base_header[b'NAXIS1']/2
 
             #other header values.
             base_header[b'NAXIS'] = 2

--- a/turbo_seti/findoppler/file_writers.py
+++ b/turbo_seti/findoppler/file_writers.py
@@ -77,7 +77,11 @@ class FileWriter(GeneralWriter):
         '''
 
         return None
-        self.write('# Coarse Channel Number: %i \n'%header[u'coarse_chan'])
+        
+        try:
+            self.write('# Coarse Channel Number: %i \n'%header[u'coarse_chan'])
+        except:
+            self.write('# Coarse Channel Number: %i \n'%header[b'coarse_chan'])
         info_str = '# Number of hits: %i \n'%total_n_candi
         self.write(info_str)
 
@@ -85,7 +89,10 @@ class FileWriter(GeneralWriter):
         ''' Write header information per given obs.
         '''
 
-        info_str = '# Source:%s\n# MJD: %18.12f\tRA: %s\tDEC: %s\n# DELTAT: %10.6f\tDELTAF(Hz): %10.6f\n'%(header[u'SOURCE'],header[u'MJD'], header[u'RA'], header[u'DEC'], header[u'DELTAT'], header[u'DELTAF']*1e6)
+        try:
+            info_str = '# Source:%s\n# MJD: %18.12f\tRA: %s\tDEC: %s\n# DELTAT: %10.6f\tDELTAF(Hz): %10.6f\n'%(header[u'SOURCE'],header[u'MJD'], header[u'RA'], header[u'DEC'], header[u'DELTAT'], header[u'DELTAF']*1e6)
+        except:
+            info_str = '# Source:%s\n# MJD: %18.12f\tRA: %s\tDEC: %s\n# DELTAT: %10.6f\tDELTAF(Hz): %10.6f\n'%(header[b'SOURCE'],header[b'MJD'], header[b'RA'], header[b'DEC'], header[b'DELTAT'], header[b'DELTAF']*1e6)
 
         self.write(info_str)
         self.write('# --------------------------\n')
@@ -136,7 +143,10 @@ class FileWriter(GeneralWriter):
         info_str += '%14.6f\t'%freq_end #freq_end:
         info_str += '%s\t'%obs_info['SEFDs_val'][this_one] #SEFD:
         info_str += '%14.6f\t'%obs_info['SEFDs_freq'][this_one] #SEFD_mid_freq:
-        info_str += '%i\t'%header[u'coarse_chan'] #
+        try:
+            info_str += '%i\t'%header[u'coarse_chan'] #
+        except:
+            info_str += '%i\t'%header[b'coarse_chan']
         info_str += '%i\t'%total_n_candi #
         info_str +='\n'
         self.write(info_str)

--- a/turbo_seti/findoppler/findopp.py
+++ b/turbo_seti/findoppler/findopp.py
@@ -8,14 +8,14 @@ import logging
 logger = logging.getLogger(__name__)
 import gc   #Garbage collector.
 
-from .data_handdler import DATAHandle
-from .file_writers import FileWriter, LogWriter
-from .helper_functions import chan_freq
+from data_handdler import DATAHandle
+from file_writers import FileWriter, LogWriter
+from helper_functions import chan_freq
 
 #For importing cython code
 import pyximport
 pyximport.install(setup_args={"include_dirs":np.get_include()}, reload_support=True)
-from . import taylor_tree as tt
+import taylor_tree as tt
 
 #For debugging
 #import cProfile

--- a/turbo_seti/findoppler/findopp.py
+++ b/turbo_seti/findoppler/findopp.py
@@ -172,7 +172,7 @@ class FinDoppler:
 #             hist_val.histid = np.zeros(tdwidth, dtype='uint32')
 
         #EE: Making "shoulders" to avoid "edge effects". Could do further testing.
-        specstart = (tsteps*shoulder_size/2)
+        specstart = int(tsteps*shoulder_size/2)
         specend = tdwidth - (tsteps * shoulder_size)
 
         #--------------------------------
@@ -202,26 +202,19 @@ class FinDoppler:
 
                 #/* populate neg doppler array */
                 np.copyto(tree_findoppler_flip, tree_findoppler_original)
-                print(tree_findoppler_flip.shape)
+                
                 #/* Flip matrix across X dimension to search negative doppler drift rates */
                 FlipX(tree_findoppler_flip, tdwidth, tsteps)
-                print(tree_findoppler_flip.shape)
                 logger.info("Doppler correcting reverse...")
                 tt.taylor_flt(tree_findoppler_flip, tsteps * tdwidth, tsteps)
                 logger.debug( "done...")
                 
                 complete_drift_range = data_obj.drift_rate_resolution*np.array(range(-1*tsteps_valid*(np.abs(drift_block)+1)+1,-1*tsteps_valid*(np.abs(drift_block))+1))
-                print(tree_findoppler_flip.shape, complete_drift_range.shape)
                 for k,drift_rate in enumerate(complete_drift_range[(complete_drift_range<self.min_drift) & (complete_drift_range>=-1*self.max_drift)]):
                     # indx  = ibrev[drift_indices[::-1][k]] * tdwidth
                     indx  = ibrev[drift_indices[::-1][(complete_drift_range<self.min_drift) & (complete_drift_range>=-1*self.max_drift)][k]] * tdwidth
 
                     #/* SEARCH NEGATIVE DRIFT RATES */
-                    print(indx, tdwidth)
-                    print(indx + tdwidth)
-                    print(type(indx), type(tdwidth), type(indx[0]))
-                    print(indx.shape, (indx+tdwidth).shape, tree_findoppler_flip.shape, ibrev.shape)
-                    
                     spectrum = tree_findoppler_flip[indx: indx + tdwidth]
 
                     #/* normalize */
@@ -298,8 +291,10 @@ class FinDoppler:
 
 #         self.filewriter.report_coarse_channel(data_obj.header,max_val.total_n_candi)
         self.filewriter = tophitsearch(tree_findoppler_original, max_val, tsteps, nframes, data_obj.header, tdwidth, fftlen, self.max_drift,data_obj.obs_length, out_dir = self.out_dir, logwriter=self.logwriter, filewriter=self.filewriter, obs_info = self.obs_info)
-        logger.info("Total number of candidates for coarse channel "+ str(data_obj.header[u'coarse_chan']) +" is: %i"%max_val.total_n_candi)
-
+        try:
+            logger.info("Total number of candidates for coarse channel "+ str(data_obj.header[u'coarse_chan']) +" is: %i"%max_val.total_n_candi)
+        except:
+            logger.info("Total number of candidates for coarse channel "+ str(data_obj.header[b'coarse_chan']) +" is: %i"%max_val.total_n_candi)
 
 #  ======================================================================  #
 

--- a/turbo_seti/findoppler/helper_functions.py
+++ b/turbo_seti/findoppler/helper_functions.py
@@ -4,11 +4,19 @@ import numpy as np
 
 
 def chan_freq(header, fine_channel, tdwidth, ref_frame):
-    fftlen = header[u'NAXIS1']
-    chan_index = fine_channel - (tdwidth-fftlen)/2
-    chanfreq = header[u'FCNTR'] + (chan_index - fftlen/2)*header[u'DELTAF']
+    try:
+        fftlen = header[u'NAXIS1']
+        chan_index = fine_channel - (tdwidth-fftlen)/2
+        chanfreq = header[u'FCNTR'] + (chan_index - fftlen/2)*header[u'DELTAF']
+    except:
+        fftlen = header[b'NAXIS1']
+        chan_index = fine_channel - (tdwidth-fftlen)/2
+        chanfreq = header[b'FCNTR'] + (chan_index - fftlen/2)*header[b'DELTAF']
     #/* apply doppler correction */
     if ref_frame == 1:
-        chanfreq = (1 - header[u'baryv']) * chanfreq
+        try:
+            chanfreq = (1 - header[u'baryv']) * chanfreq
+        except:
+            chanfreq = (1 - header[b'baryv']) * chanfreq
     return chanfreq
 

--- a/turbo_seti/findoppler/seti_event.py
+++ b/turbo_seti/findoppler/seti_event.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 
-from .findopp import FinDoppler
+from findopp import FinDoppler
 
 import sys
 import os


### PR DESCRIPTION
The README had some out of date info, especially for working with turbo_seti within Python scripts, so I made a few small changes there.

More importantly, I went through and updated all the cases where the Python 3 implementation would break from bytestrings / integer division. The dedoppler script now should work for both versions of Python -- checked on multiple GBT filterbank data files.