### PR TITLE
It is not necessary to specify an HDF5_PLUGIN_PATH

### DIFF
--- a/turbo_seti/findoppler/seti_event.py
+++ b/turbo_seti/findoppler/seti_event.py
@@ -1,5 +1,7 @@
 #!/usr/bin/env python
 
+import hdf5plugin # It is not necessary to specify an HDF5_PLUGIN_PATH
+
 from .findopp import FinDoppler
 
 import sys


### PR DESCRIPTION
Modify seti_event.py to have as the top-most import statement (immediately following #!/usr/bin/env python):

import hdf5plugin

Then, there is no need to explicitly set the environment variable outside the program nor know where exactly the plugin resides.