### PR TITLE
Added a n_coarse_chan parameter to command line

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,7 @@ from Cython.Distutils import build_ext
 import numpy
 from setuptools.extension import Extension
 
-__version__ = "1.0.2"
+__version__ = "1.1.0"
 
 with open("README.md", "r") as fh:
     long_description = fh.read()

--- a/turbo_seti/findoppler/findopp.py
+++ b/turbo_seti/findoppler/findopp.py
@@ -44,20 +44,16 @@ class hist_vals:
 
 class FinDoppler:
     """ """
-    def __init__(self, datafile, max_drift, min_drift = 0, snr = 25.0, out_dir = './', coarse_chans = None, obs_info = None, flagging = None):
+    def __init__(self, datafile, max_drift, min_drift=0, snr=25.0, out_dir='./', coarse_chans=None, obs_info=None, flagging=None, n_coarse_chan=None):
         self.min_drift = min_drift
         self.max_drift = max_drift
         self.snr = snr
         self.out_dir = out_dir
-        self.data_handle = DATAHandle(datafile,out_dir=out_dir)
+
+        self.data_handle = DATAHandle(datafile, out_dir=out_dir, n_coarse_chan=n_coarse_chan, coarse_chans=coarse_chans)
         if (self.data_handle is None) or (self.data_handle.status is False):
             raise IOError("File error, aborting...")
-        if coarse_chans:
-            if int(coarse_chans[-1]) > len(self.data_handle.data_list) or int(coarse_chans[0]) > len(self.data_handle.data_list):
-                raise ValueError('The coarse channel(s) given (%i,%i) is outside the possible range (0,%i) '%(int(coarse_chans[0]),int(coarse_chans[-1]),len(self.data_handle.data_list)))
-            if int(coarse_chans[-1]) < 0 or int(coarse_chans[0]) < 0:
-                raise ValueError('The coarse channel(s) given (%i,%i) is outside the possible range (0,%i) '%(int(coarse_chans[0]),int(coarse_chans[-1]),len(self.data_handle.data_list)))
-            self.data_handle.data_list = self.data_handle.data_list[int(coarse_chans[0]):int(coarse_chans[-1])]
+
         logger.info(self.data_handle.get_info())
         logger.info("A new FinDoppler instance created!")
         self.obs_info = obs_info

--- a/turbo_seti/findoppler/seti_event.py
+++ b/turbo_seti/findoppler/seti_event.py
@@ -14,7 +14,9 @@ from optparse import OptionParser
 #import pdb;# pdb.set_trace()
 
 def make_list(option, opt_str, value, parser):
-    setattr(parser.values, option.dest, value.replace('[','').replace(']','').split(','))
+    v = value.replace('[','').replace(']','').split(',')
+    v = list(map(int, v))
+    setattr(parser.values, option.dest, v)
 
 def main():
 
@@ -28,7 +30,10 @@ def main():
     p.add_option('-o', '--out_dir', dest='out_dir', type='str', default='./', help='Location for output files. Default: local dir. ')
 #    p.add_option('-w', '--width', dest='slice_width', type='int', default=512, help='')
     p.add_option('-l', '--loglevel', dest='loglevel', type='str', default='info', help='Specify log level (info, debug)')
-    p.add_option('-c', '--coarse_chans', dest='coarse_chans', type='str', action='callback', default='',callback=make_list, help='Coma separated list of coarse channels to analyze.(ie. "5,8" to do from 5th to 8th coarse channels)')
+    p.add_option('-c', '--coarse_chans', dest='coarse_chans', type='str', action='callback', default='', callback=make_list,
+                 help='Comma separated list of coarse channels to analyze.(ie. "5,8" to do from 5th to 8th coarse channels)')
+    p.add_option('-n', '--n_coarse_chan', dest='n_coarse_chan', type=int, default=None,
+                 help='Number of coarse channels in file.')
     opts, args = p.parse_args(sys.argv[1:])
 
     if len(args)!=1:
@@ -72,7 +77,8 @@ def main():
 
         logging.basicConfig(format=format,stream=stream,level = level_log)
 
-        find_seti_event = FinDoppler(filename, max_drift = opts.max_drift, snr = opts.snr, out_dir = opts.out_dir,coarse_chans = opts.coarse_chans, obs_info=obs_info)
+        find_seti_event = FinDoppler(filename, max_drift=opts.max_drift, snr=opts.snr, out_dir=opts.out_dir,
+                                     coarse_chans=opts.coarse_chans, obs_info=obs_info, n_coarse_chan=opts.n_coarse_chan)
         find_seti_event.search()
 ##EE-benshmark    cProfile.runctx('find_seti_event.search()',globals(),locals(),filename='profile_search_M%2.1f_S%2.1f_t%i'%(opts.max_drift,opts.snr,int(os.times()[-1])))
 


### PR DESCRIPTION
This should allow handling of files not generated by the GBT, by adding a command line flag `-n` to `turboSETI`. 

```
Usage: turboSETI <FULL_PATH_TO_FIL_FILE> [options]

Options:
  -h, --help            show this help message and exit
  -M MAX_DRIFT, --max_drift=MAX_DRIFT
                        Set the drift rate to search. Unit: Hz/sec. Default:
                        10.0
  -s SNR, --snr=SNR     SNR threshold. Default: 25.0
  -o OUT_DIR, --out_dir=OUT_DIR
                        Location for output files. Default: local dir.
  -l LOGLEVEL, --loglevel=LOGLEVEL
                        Specify log level (info, debug)
  -c COARSE_CHANS, --coarse_chans=COARSE_CHANS
                        Comma separated list of coarse channels to
                        analyze.(ie. "5,8" to do from 5th to 8th coarse
                        channels)
  -n N_COARSE_CHAN, --n_coarse_chan=N_COARSE_CHAN
                        Number of coarse channels in file
```