### PR TITLE
Fix Reversed Frequencies

### DIFF
--- a/turbo_seti/find_event/plot_event.py
+++ b/turbo_seti/find_event/plot_event.py
@@ -161,6 +161,10 @@ def plot_waterfall(fil,
     if plot_data.shape[1] > MAX_IMSHOW_POINTS[1]:
         dec_fac_y =  int(np.ceil(plot_data.shape[1] /  MAX_IMSHOW_POINTS[1]))
     plot_data = rebin(plot_data, dec_fac_x, dec_fac_y)
+	
+	#fix case where frequencies are reversed by fil.grab_data()
+	if plot_f[-1] < plot_f[0]:
+		plot_f = plot_f[::-1]
 
     #determine extent of the plotting panel for imshow
     extent=(plot_f[0], plot_f[-1], (fil.timestamps[-1]-fil.timestamps[0])*24.*60.*60, 0.0)

--- a/turbo_seti/find_event/plot_event.py
+++ b/turbo_seti/find_event/plot_event.py
@@ -3,44 +3,44 @@
 '''
 Part of the Breakthrough Listen software package turboSETI
 
-Backend script to plot drifting, narrowband events in a generalized cadence of
+Backend script to plot drifting, narrowband events in a generalized cadence of 
 ON-OFF radio SETI observations.
 
 The main function contained in this file is *plot_candidate_events*
-    Plot_candidate_events uses the other helper functions in this file
-    (described below) to plot events from a turboSETI event .csv file.
-
+    Plot_candidate_events uses the other helper functions in this file 
+    (described below) to plot events from a turboSETI event .csv file. 
+    
 The following helper functions are contained in this file:
-    overlay_drift           - creates a dashed red line at the recorded
+    overlay_drift           - creates a dashed red line at the recorded 
                               frequency and drift rate of the plotted event -
-                              can overlay the signal exactly or be offset by
+                              can overlay the signal exactly or be offset by 
                               some amount (offset can be 0 or 'auto')
-    plot_waterfall          - makes a single-panel waterfall plot (frequency
-                              vs. time vs. intensity) for one of the on or off
-                              observations in the cadence of interest, at the
-                              frequency of the expected event. Calls
+    plot_waterfall          - makes a single-panel waterfall plot (frequency 
+                              vs. time vs. intensity) for one of the on or off 
+                              observations in the cadence of interest, at the 
+                              frequency of the expected event. Calls 
                               overlay_drift
-    make_waterfall_plots    - makes a series of waterfall plots, to be read
-                              from top to bottom, displaying a full cadence
-                              at the frequency of a recorded event from
+    make_waterfall_plots    - makes a series of waterfall plots, to be read 
+                              from top to bottom, displaying a full cadence 
+                              at the frequency of a recorded event from 
                               find_event. Calls plot_waterfall
-    plot_candidate_events   - Calls make_waterfall_plots on each event in the
+    plot_candidate_events   - Calls make_waterfall_plots on each event in the 
                               input .csv file
-
+                      
 Usage (beta):
     It is highly recommended that users interact with this program via the
     front-facing plot_event_pipeline.py script. See the usage of that file in
-    its own documentation.
-
+    its own documentation. 
+    
     If you would like to run plot_candidate_events without calling
     plot_event_pipeline.py, the usage is as follows:
-
-    plot_event.plot_candidate_events(candidate_event_dataframe,
-                                     fil_file_list,
-                                     filter_level,
+    
+    plot_event.plot_candidate_events(candidate_event_dataframe, 
+                                     fil_file_list, 
+                                     filter_level, 
                                      source_name_list,
                                      offset=0)
-
+        
     candidate_event_dataframe   A pandas dataframe containing information
                                 about a candidate event. The necessary data
                                 includes the start and stop frequencies, the
@@ -48,15 +48,15 @@ Usage (beta):
                                 the required variable names and formatting
                                 conventions, see the output of
                                 find_event_pipeline.
-
-    fil_file_list               A Python list that contains a series of
-                                strings corresponding to the filenames of .fil
-                                files, each on a new line, that corresponds to
-                                the cadence used to create the .csv file used
+                   
+    fil_file_list               A Python list that contains a series of 
+                                strings corresponding to the filenames of .fil 
+                                files, each on a new line, that corresponds to 
+                                the cadence used to create the .csv file used 
                                 for event_csv_string.
-
-    filter_level                A string indicating the filter level of the
-                                cadence used to generate the
+                   
+    filter_level                A string indicating the filter level of the 
+                                cadence used to generate the 
                                 candidate_event_dataframe. Used only for
                                 output file naming, convention is "f1", "f2",
                                 or "f3". Descriptions for the three levels of
@@ -67,24 +67,24 @@ Usage (beta):
                                 corresponding to the source names of the
                                 cadence in chronological (descending through
                                 the plot panels) cadence.
-
-    offset                      The amount that the overdrawn "best guess"
-                                line from the event parameters in the csv
-                                should be shifted from its original position
-                                to enhance readability. Can be set to 0
+                        
+    offset                      The amount that the overdrawn "best guess" 
+                                line from the event parameters in the csv 
+                                should be shifted from its original position 
+                                to enhance readability. Can be set to 0 
                                 (default; draws line on top of estimated
-                                event) or 'auto' (shifts line to the left by
-                                an auto-calculated amount, with addition lines
+                                event) or 'auto' (shifts line to the left by 
+                                an auto-calculated amount, with addition lines 
                                 showing original position).
 
-author:
+author: 
     Version 2.0 - Sofia Sheikh (ssheikhmsa@gmail.com) and Karen Perez (kip2105@columbia.edu)
     Version 1.0 - Emilio Enriquez (jeenriquez@gmail.com)
-
+    
 Last updated: 07/22/2020
 
 '''
-import matplotlib
+import matplotlib	
 matplotlib.use('agg')
 
 #General packages import
@@ -107,34 +107,34 @@ font = {'family' : 'DejaVu Sans',
 MAX_IMSHOW_POINTS = (4096, 1268)
 
 def overlay_drift(f_event, f_start, f_stop, drift_rate, t_duration, offset=0):
-    '''creates a dashed red line at the recorded frequency and drift rate of
-    the plotted event - can overlay the signal exactly or be offset by
+    '''creates a dashed red line at the recorded frequency and drift rate of 
+    the plotted event - can overlay the signal exactly or be offset by 
     some amount (offset can be 0 or 'auto')
     '''
     #determines automatic offset and plots offset lines
     if offset == 'auto':
         offset = ((f_start - f_stop) / 10)
-        plt.plot((f_event - offset, f_event),
+        plt.plot((f_event - offset, f_event), 
                  (10, 10),
                  "o-",
                  c='#cc0000',
                  lw=2)
-
+    
     #plots drift overlay line, with offset if desired
-    plt.plot((f_event + offset, f_event + drift_rate/1e6 * t_duration + offset),
-             (0, t_duration),
-             c='#cc0000',
+    plt.plot((f_event + offset, f_event + drift_rate/1e6 * t_duration + offset), 
+             (0, t_duration), 
+             c='#cc0000', 
              ls='dashed', lw=2)
 
-def plot_waterfall(fil,
+def plot_waterfall(fil, 
                    source_name,
-                   f_start=None,
+                   f_start=None, 
                    f_stop=None,
-                   drift_rate=None,
+                   drift_rate=None, 
                    logged=True,
                    plot_snr=False,
                    **kwargs):
-
+    
     """ Plot waterfall of data in a .fil or .h5 file
     Args:
         fil (str): filterbank file containing the dynamic spectrum data
@@ -154,17 +154,13 @@ def plot_waterfall(fil,
 
     #Make sure waterfall plot is under 4k*4k
     dec_fac_x, dec_fac_y = 1, 1
-
+    
     #rebinning data to plot correctly with fewer points
     if plot_data.shape[0] > MAX_IMSHOW_POINTS[0]:
-        dec_fac_x = plot_data.shape[0] / MAX_IMSHOW_POINTS[0]
+        dec_fac_x = plot_data.shape[0] / MAX_IMSHOW_POINTS[0] 
     if plot_data.shape[1] > MAX_IMSHOW_POINTS[1]:
         dec_fac_y =  int(np.ceil(plot_data.shape[1] /  MAX_IMSHOW_POINTS[1]))
     plot_data = rebin(plot_data, dec_fac_x, dec_fac_y)
-
-    #fix case where frequencies are reversed from fil.grab_data()
-    if plot_f[-1] < plot_f[0]:
-        plot_f = plot_f[::-1]
 
     #determine extent of the plotting panel for imshow
     extent=(plot_f[0], plot_f[-1], (fil.timestamps[-1]-fil.timestamps[0])*24.*60.*60, 0.0)
@@ -175,7 +171,7 @@ def plot_waterfall(fil,
     if kwargs['logged'] == True:
         plot_data = 10*np.log10(plot_data)
         kwargs.pop('logged')
-
+        
     #get normalization parameters
     vmin = plot_data.min()
     vmax = plot_data.max()
@@ -193,28 +189,28 @@ def plot_waterfall(fil,
     #add plot labels
     plt.xlabel("Frequency [Hz]",fontdict=font)
     plt.ylabel("Time [s]",fontdict=font)
-
+    
     #add source name
     ax = plt.gca()
     plt.text(0.03, 0.8, source_name, transform=ax.transAxes, bbox=dict(facecolor='white'))
     #if plot_snr != False:
     #    plt.text(0.03, 0.6, plot_snr, transform=ax.transAxes, bbox=dict(facecolor='white'))
     #return plot
-    return this_plot
+    return this_plot 
 
-def make_waterfall_plots(fil_file_list,
-                         on_source_name,
-                         f_start,
-                         f_stop,
-                         drift_rate,
-                         f_mid,
-                         filter_level,
+def make_waterfall_plots(fil_file_list, 
+                         on_source_name, 
+                         f_start, 
+                         f_stop, 
+                         drift_rate, 
+                         f_mid, 
+                         filter_level, 
                          source_name_list,
                          bandwidth,
                          offset=0,
                          plot_snr_list=False,
                          **kwargs):
-
+    
     ''' Makes waterfall plots of an event for an entire on-off cadence
     Args:
         fil_file_list (str): list of filterbank files in the cadence
@@ -228,7 +224,7 @@ def make_waterfall_plots(fil_file_list,
         bandwidth = width of the plot, incorporating drift info
         kwargs: keyword args to be passed to matplotlib imshow()
     '''
-
+    
     #prepare for plotting
     matplotlib.rc('font', **font)
 
@@ -240,32 +236,32 @@ def make_waterfall_plots(fil_file_list,
     fil1 = bl.Waterfall(fil_file_list[0], f_start=f_start, f_stop=f_stop)
     t0 = fil1.header['tstart']
     plot_f1, plot_data1 = fil1.grab_data()
-
+    
     #rebin data to plot correctly with fewer points
     dec_fac_x, dec_fac_y = 1, 1
     if plot_data1.shape[0] > MAX_IMSHOW_POINTS[0]:
-        dec_fac_x = plot_data1.shape[0] / MAX_IMSHOW_POINTS[0]
+        dec_fac_x = plot_data1.shape[0] / MAX_IMSHOW_POINTS[0] 
     if plot_data1.shape[1] > MAX_IMSHOW_POINTS[1]:
         dec_fac_y =  int(np.ceil(plot_data1.shape[1] /  MAX_IMSHOW_POINTS[1]))
     plot_data1 = rebin(plot_data1, dec_fac_x, dec_fac_y)
-
+    
     #define more plot parameters
     delta_f = 0.000250
     mid_f = np.abs(f_start+f_stop)/2.
-
+    
     subplots = []
-
+        
     #Fill in each subplot for the full plot
     for i,filename in enumerate(fil_file_list):
         #identify panel
         subplot = plt.subplot(n_plots,1,i+1)
         subplots.append(subplot)
-
+        
         if plot_snr_list != False:
             plot_snr = plot_snr_list[i]
         else:
             plot_snr = False
-
+        
         #read in data
         fil = bl.Waterfall(filename, f_start=f_start, f_stop=f_stop)
         try:
@@ -273,26 +269,26 @@ def make_waterfall_plots(fil_file_list,
             source_name = source_name_list[i]
             this_plot = plot_waterfall(fil,
                                        source_name,
-                                       f_start=f_start,
-                                       f_stop=f_stop,
+                                       f_start=f_start, 
+                                       f_stop=f_stop, 
                                        drift_rate=drift_rate,
                                        plot_snr=plot_snr,
                                        **kwargs)
-
+            
             #calculate parameters for estimated drift line
             t_elapsed = Time(fil.header['tstart'], format='mjd').unix - Time(t0, format='mjd').unix
             t_duration = (fil.n_ints_in_file - 1) * fil.header['tsamp']
             f_event = f_mid + drift_rate / 1e6 * t_elapsed
-
+            
             #plot estimated drift line
             overlay_drift(f_event, f_start, f_stop, drift_rate, t_duration, offset)
         except:
             raise
-
+            
         #Title the full plot
         if i == 0:
             plot_title = "%s \n $\dot{\\nu}$ = %2.3f Hz/s , MJD:%5.5f" % (on_source_name, drift_rate, t0)
-
+            
             plt.title(plot_title)
         #Format full plot
         if i < len(fil_file_list)-1:
@@ -301,7 +297,7 @@ def make_waterfall_plots(fil_file_list,
     #More overall plot formatting, axis labelling
     factor = 1e6
     units = 'Hz'
-
+            
     ax = plt.gca()
     ax.get_xaxis().get_major_formatter().set_useOffset(False)
     xloc = np.linspace(f_start, f_stop, 5)
@@ -311,35 +307,35 @@ def make_waterfall_plots(fil_file_list,
         units = 'kHz'
     plt.xticks(xloc, xticks)
     plt.xlabel("Relative Frequency [%s] from %f MHz"%(units,mid_f),fontdict=font)
-
+    
     #Add colorbar
     cax = fig[0].add_axes([0.94, 0.11, 0.03, 0.77])
     fig[0].colorbar(this_plot,cax=cax,label='Normalized Power (Arbitrary Units)')
-
+    
     #Adjust plots
     plt.subplots_adjust(hspace=0,wspace=0)
-
+    
     #save the figures
     plt.savefig(filter_level + '_' + on_source_name + '_dr_' + "{:0.2f}".format(drift_rate) + '_freq_' "{:0.6f}".format(f_start) + ".png",
                bbox_inches='tight')
 
     return subplots
 
-def plot_candidate_events(candidate_event_dataframe,
-                          fil_file_list,
-                          filter_level,
+def plot_candidate_events(candidate_event_dataframe, 
+                          fil_file_list, 
+                          filter_level, 
                           source_name_list,
-                          offset=0,
+                          offset=0, 
                           plot_snr_list=False,
                           **kwargs):
-
+    
     #load in the data for each individual hit
     for i in range(0, len(candidate_event_dataframe)):
         candidate = candidate_event_dataframe.iloc[i]
         on_source_name = candidate['Source']
         f_mid = candidate['Freq']
         drift_rate = candidate['DriftRate']
-
+            
         #calculate the length of the total cadence from the fil files' headers
         first_fil = bl.Waterfall(fil_file_list[0], load_data=False)
         tfirst = first_fil.header['tstart']
@@ -357,28 +353,28 @@ def plot_candidate_events(candidate_event_dataframe,
         #Print useful values
         print('')
         print('*************************************************')
-        print('***     The Parameters for This Plot Are:    ****')
+        print('***     The Parameters for This Plot Are:    ****')   
         print('Target = ', on_source_name)
         print('Bandwidth = ', round(bandwidth, 5), ' MHz')
         print('Time Elapsed (inc. Slew) = ', round(t_elapsed), ' s')
         print('Middle Frequency = ', round(f_mid, 4), " MHz")
-        print('Expected Drift = ', round(drift_rate, 4), " Hz/s")
+        print('Expected Drift = ', round(drift_rate, 4), " Hz/s") 
         print('*************************************************')
         print('*************************************************')
         print('')
-
+        
         #Pass info to make_waterfall_plots() function
-        make_waterfall_plots(fil_file_list,
-                             on_source_name,
-                             f_start,
-                             f_stop,
-                             drift_rate,
-                             f_mid,
+        make_waterfall_plots(fil_file_list, 
+                             on_source_name, 
+                             f_start, 
+                             f_stop, 
+                             drift_rate, 
+                             f_mid, 
                              filter_level,
                              source_name_list,
                              bandwidth,
-                             offset=offset,
+                             offset=offset, 
                              plot_snr_list=plot_snr_list,
                              **kwargs)
-
-    return
+    
+    return 

--- a/turbo_seti/find_event/plot_event.py
+++ b/turbo_seti/find_event/plot_event.py
@@ -3,44 +3,44 @@
 '''
 Part of the Breakthrough Listen software package turboSETI
 
-Backend script to plot drifting, narrowband events in a generalized cadence of 
+Backend script to plot drifting, narrowband events in a generalized cadence of
 ON-OFF radio SETI observations.
 
 The main function contained in this file is *plot_candidate_events*
-    Plot_candidate_events uses the other helper functions in this file 
-    (described below) to plot events from a turboSETI event .csv file. 
-    
+    Plot_candidate_events uses the other helper functions in this file
+    (described below) to plot events from a turboSETI event .csv file.
+
 The following helper functions are contained in this file:
-    overlay_drift           - creates a dashed red line at the recorded 
+    overlay_drift           - creates a dashed red line at the recorded
                               frequency and drift rate of the plotted event -
-                              can overlay the signal exactly or be offset by 
+                              can overlay the signal exactly or be offset by
                               some amount (offset can be 0 or 'auto')
-    plot_waterfall          - makes a single-panel waterfall plot (frequency 
-                              vs. time vs. intensity) for one of the on or off 
-                              observations in the cadence of interest, at the 
-                              frequency of the expected event. Calls 
+    plot_waterfall          - makes a single-panel waterfall plot (frequency
+                              vs. time vs. intensity) for one of the on or off
+                              observations in the cadence of interest, at the
+                              frequency of the expected event. Calls
                               overlay_drift
-    make_waterfall_plots    - makes a series of waterfall plots, to be read 
-                              from top to bottom, displaying a full cadence 
-                              at the frequency of a recorded event from 
+    make_waterfall_plots    - makes a series of waterfall plots, to be read
+                              from top to bottom, displaying a full cadence
+                              at the frequency of a recorded event from
                               find_event. Calls plot_waterfall
-    plot_candidate_events   - Calls make_waterfall_plots on each event in the 
+    plot_candidate_events   - Calls make_waterfall_plots on each event in the
                               input .csv file
-                      
+
 Usage (beta):
     It is highly recommended that users interact with this program via the
     front-facing plot_event_pipeline.py script. See the usage of that file in
-    its own documentation. 
-    
+    its own documentation.
+
     If you would like to run plot_candidate_events without calling
     plot_event_pipeline.py, the usage is as follows:
-    
-    plot_event.plot_candidate_events(candidate_event_dataframe, 
-                                     fil_file_list, 
-                                     filter_level, 
+
+    plot_event.plot_candidate_events(candidate_event_dataframe,
+                                     fil_file_list,
+                                     filter_level,
                                      source_name_list,
                                      offset=0)
-        
+
     candidate_event_dataframe   A pandas dataframe containing information
                                 about a candidate event. The necessary data
                                 includes the start and stop frequencies, the
@@ -48,15 +48,15 @@ Usage (beta):
                                 the required variable names and formatting
                                 conventions, see the output of
                                 find_event_pipeline.
-                   
-    fil_file_list               A Python list that contains a series of 
-                                strings corresponding to the filenames of .fil 
-                                files, each on a new line, that corresponds to 
-                                the cadence used to create the .csv file used 
+
+    fil_file_list               A Python list that contains a series of
+                                strings corresponding to the filenames of .fil
+                                files, each on a new line, that corresponds to
+                                the cadence used to create the .csv file used
                                 for event_csv_string.
-                   
-    filter_level                A string indicating the filter level of the 
-                                cadence used to generate the 
+
+    filter_level                A string indicating the filter level of the
+                                cadence used to generate the
                                 candidate_event_dataframe. Used only for
                                 output file naming, convention is "f1", "f2",
                                 or "f3". Descriptions for the three levels of
@@ -67,24 +67,24 @@ Usage (beta):
                                 corresponding to the source names of the
                                 cadence in chronological (descending through
                                 the plot panels) cadence.
-                        
-    offset                      The amount that the overdrawn "best guess" 
-                                line from the event parameters in the csv 
-                                should be shifted from its original position 
-                                to enhance readability. Can be set to 0 
+
+    offset                      The amount that the overdrawn "best guess"
+                                line from the event parameters in the csv
+                                should be shifted from its original position
+                                to enhance readability. Can be set to 0
                                 (default; draws line on top of estimated
-                                event) or 'auto' (shifts line to the left by 
-                                an auto-calculated amount, with addition lines 
+                                event) or 'auto' (shifts line to the left by
+                                an auto-calculated amount, with addition lines
                                 showing original position).
 
-author: 
+author:
     Version 2.0 - Sofia Sheikh (ssheikhmsa@gmail.com) and Karen Perez (kip2105@columbia.edu)
     Version 1.0 - Emilio Enriquez (jeenriquez@gmail.com)
-    
+
 Last updated: 07/22/2020
 
 '''
-import matplotlib	
+import matplotlib
 matplotlib.use('agg')
 
 #General packages import
@@ -107,34 +107,34 @@ font = {'family' : 'DejaVu Sans',
 MAX_IMSHOW_POINTS = (4096, 1268)
 
 def overlay_drift(f_event, f_start, f_stop, drift_rate, t_duration, offset=0):
-    '''creates a dashed red line at the recorded frequency and drift rate of 
-    the plotted event - can overlay the signal exactly or be offset by 
+    '''creates a dashed red line at the recorded frequency and drift rate of
+    the plotted event - can overlay the signal exactly or be offset by
     some amount (offset can be 0 or 'auto')
     '''
     #determines automatic offset and plots offset lines
     if offset == 'auto':
         offset = ((f_start - f_stop) / 10)
-        plt.plot((f_event - offset, f_event), 
+        plt.plot((f_event - offset, f_event),
                  (10, 10),
                  "o-",
                  c='#cc0000',
                  lw=2)
-    
+
     #plots drift overlay line, with offset if desired
-    plt.plot((f_event + offset, f_event + drift_rate/1e6 * t_duration + offset), 
-             (0, t_duration), 
-             c='#cc0000', 
+    plt.plot((f_event + offset, f_event + drift_rate/1e6 * t_duration + offset),
+             (0, t_duration),
+             c='#cc0000',
              ls='dashed', lw=2)
 
-def plot_waterfall(fil, 
+def plot_waterfall(fil,
                    source_name,
-                   f_start=None, 
+                   f_start=None,
                    f_stop=None,
-                   drift_rate=None, 
+                   drift_rate=None,
                    logged=True,
                    plot_snr=False,
                    **kwargs):
-    
+
     """ Plot waterfall of data in a .fil or .h5 file
     Args:
         fil (str): filterbank file containing the dynamic spectrum data
@@ -154,13 +154,17 @@ def plot_waterfall(fil,
 
     #Make sure waterfall plot is under 4k*4k
     dec_fac_x, dec_fac_y = 1, 1
-    
+
     #rebinning data to plot correctly with fewer points
     if plot_data.shape[0] > MAX_IMSHOW_POINTS[0]:
-        dec_fac_x = plot_data.shape[0] / MAX_IMSHOW_POINTS[0] 
+        dec_fac_x = plot_data.shape[0] / MAX_IMSHOW_POINTS[0]
     if plot_data.shape[1] > MAX_IMSHOW_POINTS[1]:
         dec_fac_y =  int(np.ceil(plot_data.shape[1] /  MAX_IMSHOW_POINTS[1]))
     plot_data = rebin(plot_data, dec_fac_x, dec_fac_y)
+
+    #fix case where frequencies are reversed from fil.grab_data()
+    if plot_f[-1] < plot_f[0]:
+        plot_f = plot_f[::-1]
 
     #determine extent of the plotting panel for imshow
     extent=(plot_f[0], plot_f[-1], (fil.timestamps[-1]-fil.timestamps[0])*24.*60.*60, 0.0)
@@ -171,7 +175,7 @@ def plot_waterfall(fil,
     if kwargs['logged'] == True:
         plot_data = 10*np.log10(plot_data)
         kwargs.pop('logged')
-        
+
     #get normalization parameters
     vmin = plot_data.min()
     vmax = plot_data.max()
@@ -189,28 +193,28 @@ def plot_waterfall(fil,
     #add plot labels
     plt.xlabel("Frequency [Hz]",fontdict=font)
     plt.ylabel("Time [s]",fontdict=font)
-    
+
     #add source name
     ax = plt.gca()
     plt.text(0.03, 0.8, source_name, transform=ax.transAxes, bbox=dict(facecolor='white'))
     #if plot_snr != False:
     #    plt.text(0.03, 0.6, plot_snr, transform=ax.transAxes, bbox=dict(facecolor='white'))
     #return plot
-    return this_plot 
+    return this_plot
 
-def make_waterfall_plots(fil_file_list, 
-                         on_source_name, 
-                         f_start, 
-                         f_stop, 
-                         drift_rate, 
-                         f_mid, 
-                         filter_level, 
+def make_waterfall_plots(fil_file_list,
+                         on_source_name,
+                         f_start,
+                         f_stop,
+                         drift_rate,
+                         f_mid,
+                         filter_level,
                          source_name_list,
                          bandwidth,
                          offset=0,
                          plot_snr_list=False,
                          **kwargs):
-    
+
     ''' Makes waterfall plots of an event for an entire on-off cadence
     Args:
         fil_file_list (str): list of filterbank files in the cadence
@@ -224,7 +228,7 @@ def make_waterfall_plots(fil_file_list,
         bandwidth = width of the plot, incorporating drift info
         kwargs: keyword args to be passed to matplotlib imshow()
     '''
-    
+
     #prepare for plotting
     matplotlib.rc('font', **font)
 
@@ -236,32 +240,32 @@ def make_waterfall_plots(fil_file_list,
     fil1 = bl.Waterfall(fil_file_list[0], f_start=f_start, f_stop=f_stop)
     t0 = fil1.header['tstart']
     plot_f1, plot_data1 = fil1.grab_data()
-    
+
     #rebin data to plot correctly with fewer points
     dec_fac_x, dec_fac_y = 1, 1
     if plot_data1.shape[0] > MAX_IMSHOW_POINTS[0]:
-        dec_fac_x = plot_data1.shape[0] / MAX_IMSHOW_POINTS[0] 
+        dec_fac_x = plot_data1.shape[0] / MAX_IMSHOW_POINTS[0]
     if plot_data1.shape[1] > MAX_IMSHOW_POINTS[1]:
         dec_fac_y =  int(np.ceil(plot_data1.shape[1] /  MAX_IMSHOW_POINTS[1]))
     plot_data1 = rebin(plot_data1, dec_fac_x, dec_fac_y)
-    
+
     #define more plot parameters
     delta_f = 0.000250
     mid_f = np.abs(f_start+f_stop)/2.
-    
+
     subplots = []
-        
+
     #Fill in each subplot for the full plot
     for i,filename in enumerate(fil_file_list):
         #identify panel
         subplot = plt.subplot(n_plots,1,i+1)
         subplots.append(subplot)
-        
+
         if plot_snr_list != False:
             plot_snr = plot_snr_list[i]
         else:
             plot_snr = False
-        
+
         #read in data
         fil = bl.Waterfall(filename, f_start=f_start, f_stop=f_stop)
         try:
@@ -269,26 +273,26 @@ def make_waterfall_plots(fil_file_list,
             source_name = source_name_list[i]
             this_plot = plot_waterfall(fil,
                                        source_name,
-                                       f_start=f_start, 
-                                       f_stop=f_stop, 
+                                       f_start=f_start,
+                                       f_stop=f_stop,
                                        drift_rate=drift_rate,
                                        plot_snr=plot_snr,
                                        **kwargs)
-            
+
             #calculate parameters for estimated drift line
             t_elapsed = Time(fil.header['tstart'], format='mjd').unix - Time(t0, format='mjd').unix
             t_duration = (fil.n_ints_in_file - 1) * fil.header['tsamp']
             f_event = f_mid + drift_rate / 1e6 * t_elapsed
-            
+
             #plot estimated drift line
             overlay_drift(f_event, f_start, f_stop, drift_rate, t_duration, offset)
         except:
             raise
-            
+
         #Title the full plot
         if i == 0:
             plot_title = "%s \n $\dot{\\nu}$ = %2.3f Hz/s , MJD:%5.5f" % (on_source_name, drift_rate, t0)
-            
+
             plt.title(plot_title)
         #Format full plot
         if i < len(fil_file_list)-1:
@@ -297,7 +301,7 @@ def make_waterfall_plots(fil_file_list,
     #More overall plot formatting, axis labelling
     factor = 1e6
     units = 'Hz'
-            
+
     ax = plt.gca()
     ax.get_xaxis().get_major_formatter().set_useOffset(False)
     xloc = np.linspace(f_start, f_stop, 5)
@@ -307,35 +311,35 @@ def make_waterfall_plots(fil_file_list,
         units = 'kHz'
     plt.xticks(xloc, xticks)
     plt.xlabel("Relative Frequency [%s] from %f MHz"%(units,mid_f),fontdict=font)
-    
+
     #Add colorbar
     cax = fig[0].add_axes([0.94, 0.11, 0.03, 0.77])
     fig[0].colorbar(this_plot,cax=cax,label='Normalized Power (Arbitrary Units)')
-    
+
     #Adjust plots
     plt.subplots_adjust(hspace=0,wspace=0)
-    
+
     #save the figures
     plt.savefig(filter_level + '_' + on_source_name + '_dr_' + "{:0.2f}".format(drift_rate) + '_freq_' "{:0.6f}".format(f_start) + ".png",
                bbox_inches='tight')
 
     return subplots
 
-def plot_candidate_events(candidate_event_dataframe, 
-                          fil_file_list, 
-                          filter_level, 
+def plot_candidate_events(candidate_event_dataframe,
+                          fil_file_list,
+                          filter_level,
                           source_name_list,
-                          offset=0, 
+                          offset=0,
                           plot_snr_list=False,
                           **kwargs):
-    
+
     #load in the data for each individual hit
     for i in range(0, len(candidate_event_dataframe)):
         candidate = candidate_event_dataframe.iloc[i]
         on_source_name = candidate['Source']
         f_mid = candidate['Freq']
         drift_rate = candidate['DriftRate']
-            
+
         #calculate the length of the total cadence from the fil files' headers
         first_fil = bl.Waterfall(fil_file_list[0], load_data=False)
         tfirst = first_fil.header['tstart']
@@ -353,28 +357,28 @@ def plot_candidate_events(candidate_event_dataframe,
         #Print useful values
         print('')
         print('*************************************************')
-        print('***     The Parameters for This Plot Are:    ****')   
+        print('***     The Parameters for This Plot Are:    ****')
         print('Target = ', on_source_name)
         print('Bandwidth = ', round(bandwidth, 5), ' MHz')
         print('Time Elapsed (inc. Slew) = ', round(t_elapsed), ' s')
         print('Middle Frequency = ', round(f_mid, 4), " MHz")
-        print('Expected Drift = ', round(drift_rate, 4), " Hz/s") 
+        print('Expected Drift = ', round(drift_rate, 4), " Hz/s")
         print('*************************************************')
         print('*************************************************')
         print('')
-        
+
         #Pass info to make_waterfall_plots() function
-        make_waterfall_plots(fil_file_list, 
-                             on_source_name, 
-                             f_start, 
-                             f_stop, 
-                             drift_rate, 
-                             f_mid, 
+        make_waterfall_plots(fil_file_list,
+                             on_source_name,
+                             f_start,
+                             f_stop,
+                             drift_rate,
+                             f_mid,
                              filter_level,
                              source_name_list,
                              bandwidth,
-                             offset=offset, 
+                             offset=offset,
                              plot_snr_list=plot_snr_list,
                              **kwargs)
-    
-    return 
+
+    return


### PR DESCRIPTION
`grab_data()` from `blimpy` will reverse the frequency array for some of the Parkes UWL data. I added a work around that re-reverses the array if the last element is less than the first (i.e. if the array has been reversed by `blimpy`). Plots below show before/after.
<img src="https://user-images.githubusercontent.com/66645011/88580057-097a6f00-d019-11ea-9875-6dc943a86e65.png" width="350" /> <img src="https://user-images.githubusercontent.com/66645011/88580058-0a130580-d019-11ea-851e-5a0bd33480ae.png" width="350" />


