### PR TITLE
Deprecate Travis CI in favor of Github Actions 

### DIFF
--- a/.github/workflows/docker_build.yml
+++ b/.github/workflows/docker_build.yml
@@ -1,0 +1,26 @@
+name: Test Dockerfile
+
+on:
+  push:
+    paths-ignore:
+      - '**.ipynb'
+      - '**.png'
+      - '**.rst'
+      - '**.md'
+  pull_request:
+    paths-ignore:
+      - '**.ipynb'
+      - '**.png'
+      - '**.rst'
+      - '**.md'
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v2
+      - name: Build the Docker image
+        run: docker build . --file Dockerfile --tag turboseti-docker:$(date +%s)
+

--- a/.github/workflows/push_docker.yml
+++ b/.github/workflows/push_docker.yml
@@ -1,0 +1,24 @@
+name: Push to Docker Hub
+
+on:
+  push:
+    paths-ignore:
+      - '**.rst'
+    branches:
+      - master
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v2
+      - name: Push to Docker Hub
+        uses: docker/build-push-action@v1
+        with:
+          username: ${{ secrets.DOCKER_USER }}
+          password: ${{ secrets.DOCKER_PASS }}
+          repository: ucberkeleyseti/turbo_seti
+          tags: latest
+

--- a/.github/workflows/python_tests.yml
+++ b/.github/workflows/python_tests.yml
@@ -1,0 +1,55 @@
+name: Test TurboSETI
+
+on:
+  push:
+    paths-ignore:
+      - '**.ipynb'
+      - '**.png'
+      - '**.rst'
+      - '**.md'
+  pull_request:
+    paths-ignore:
+      - '**.ipynb'
+      - '**.png'
+      - '**.rst'
+      - '**.md'
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-verison: [3.7, 3.8, 3.9]
+
+    steps:
+      - uses: actions/checkout@v2
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v2
+        with:
+          python-version: ${{ matrix.python-version }}
+      - name: Install system dependencies
+        run: |
+          sudo apt update
+          cat dependencies.txt | sudo xargs -n 1 apt install -y
+      - name: Install dependencies
+        run: |
+          python3 -m pip install --upgrade pip
+          python3 -m pip install -r requirements.txt
+          python3 -m pip install -r requirements_test.txt
+      - name: Download test files
+        run: |
+          export PATH=/home/runner/.local/bin:$PATH
+          cdtest
+          python3 download_test_data.py
+          cd ..
+      - name: Run coverage test
+        run: |
+          export PATH=/home/runner/.local/bin:$PATH
+          python3 -m pytest --cov=./ --cov-report=xml
+      - name: Upload coverage to Codecov
+        uses: codecov/codecov-action@v1
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+          name: turboseti-codecov-p${{ matrix.python-version }}
+

--- a/.github/workflows/python_tests.yml
+++ b/.github/workflows/python_tests.yml
@@ -40,7 +40,7 @@ jobs:
       - name: Download test files
         run: |
           export PATH=/home/runner/.local/bin:$PATH
-          cdtest
+          cd test
           python3 download_test_data.py
           cd ..
       - name: Run coverage test

--- a/.gitignore
+++ b/.gitignore
@@ -18,6 +18,6 @@ dist/
 docs/_build/
 exec
 
-test/.coverage
-test/htmlcov
-test/coverage.xml
+.coverage
+htmlcov
+coverage.xml

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,50 +1,27 @@
-# To compile this with docker use:
-# docker build --tag turbo_seti .
-# Then to run it:
-# docker run --rm -it turbo_seti
-# To be able to access local disk on Mac OSX, you need to use Docker for Mac GUI
-# and click on 'File sharing', then add your directory, e.g. /data/bl_pks
-# Then to run it:
-# docker run --rm -it -v /data/bl_pks:/mnt/data turbo_seti
-# And if you want to access a port, you need to do a similar thing:
-# docker run --rm -it -p 9876:9876 sigpyproc
-
-# INSTALL BASE FROM KERN SUITE
-FROM kernsuite/base:3
+FROM ubuntu:20.04
 ARG DEBIAN_FRONTEND=noninteractive
 
-ENV TERM xterm
+RUN apt-get update
 
-######
-# Do docker apt-installs
-RUN docker-apt-install build-essential python3-setuptools python3-pip python3-tk pkg-config
-RUN docker-apt-install curl wget make cmake git
-RUN docker-apt-install libomp-dev
-RUN docker-apt-install libhdf5-serial-dev libhdf5-dev libhdf5-cpp-11
+COPY . /turboseti
+WORKDIR /turboseti
 
-#####
-# Pip installation of python packages
-RUN python3 -m pip install --upgrade pip
-RUN python3 -m pip install --upgrade setuptools wheel
-RUN python3 -m pip install numpy
-RUN python3 -m pip install pandas numba astropy matplotlib
-RUN python3 -m pip install --only-binary=scipy scipy
-RUN python3 -m pip install pytest
-RUN python3 -m pip install git+https://github.com/ucberkeleyseti/blimpy
-
-######
-# HDF5 fixup
-# Ubuntu 16.04 has a crazy hdf5 setup, needs some massaging, and extra flags to install h5py
-RUN ln -s /usr/lib/x86_64-linux-gnu/libhdf5_serial.so /usr/lib/x86_64-linux-gnu/libhdf5.so
-RUN ln -s /usr/lib/x86_64-linux-gnu/libhdf5_serial_hl.so /usr/lib/x86_64-linux-gnu/libhdf5_hl.so
-
-RUN CFLAGS=-I/usr/include/hdf5/serial pip install h5py
+RUN cat dependencies.txt | xargs -n 1 apt install --no-install-recommends -y
 
 
-
-# Finally, install!
-COPY . .
+RUN python3 -m pip install -r requirements.txt
+RUN python3 -m pip install pytest pyslalib
 RUN python3 setup.py install
 
+RUN python3 -m pip install -r requirements_test.txt
+RUN cd test && python3 download_test_data.py && cd ..
+RUN cd test && bash run_tests.sh && cd ..
 
+RUN find test -name "*.h5" -type f -delete
+RUN find test -name "*.log" -type f -delete
+RUN find test -name "*.dat" -type f -delete
+RUN find test -name "*.fil" -type f -delete
+RUN find test -name "*.png" -type f -delete
+RUN find . -path '*/__pycache__*' -delete
 
+WORKDIR /home

--- a/VERSION-HISTORY.md
+++ b/VERSION-HISTORY.md
@@ -4,6 +4,7 @@ This file is a version history of turbo_seti amendments, beginning with version 
 | Version | Contents |
 | :--: | -- |
 | 2.1.0 **coming soon** | Add frequency channel masking capability. See issue #125. |
+| 2.0.4 | Add GitHub Actions Workflows for CI instead of Travis CI. |
 | 2.0.3 | Fix issue #135 by reverting changes made by PR #121 and #113. |
 | 2.0.2 | Amended `find_doppler.py`, `seti_event.py`, and `plot_event.py` to ressurect logging. See issue \#134. |
 | 2.0.1 | Amended `plot_event_pipeline.py` to accept a new filter_spec parameter. See issue \#127. |

--- a/dependencies.txt
+++ b/dependencies.txt
@@ -1,0 +1,8 @@
+python3-pip
+python3-dev
+python3-setuptools
+libhdf5-dev
+gfortran
+wget
+curl
+git

--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ from setuptools import setup, find_packages
 import numpy
 from setuptools.extension import Extension
 
-__version__ = "2.0.3"
+__version__ = "2.0.4"
 
 with open("README.md", "r") as fh:
     long_description = fh.read()


### PR DESCRIPTION
This is a pull-request documenting the changes from Travis CI to Github Actions. A future PR will add GPU tests.

### Goals
- Deprecate Travis CI.

### Approach
#### On Commit or Pull-Request
Test and validate the integrity of each commit to any branch.

1. `python_tests.yml`: Run Python tests with coverage report.
2.  `docker_build.yml`: Run build test with Docker.

#### On Master Commit
Publish the image to Docker Hub after a commit to `master` branch.

1. `push_docker.yml`: Build & publish the image on Docker Hub.

### Required Secrets
- **DOCKER_USER**: Docker Hub Username.
- **DOCKER_PASS**: Docker Hub Password.
- **CODECOV_TOKEN**: Codecov Blimpy Token.