### PR TITLE
Address issues #141 and #135 (find_doppler.py)

### DIFF
--- a/VERSION-HISTORY.md
+++ b/VERSION-HISTORY.md
@@ -4,6 +4,7 @@ This file is a version history of turbo_seti amendments, beginning with version 
 | Version | Contents |
 | :--: | -- |
 | 2.1.0 **coming soon** | Add frequency channel masking capability. See issue #125. |
+| 2.0.6.7 | Fix issue #141, #135 - Fixed find_doppler.py from dropping one subrange of drift rates |
 | 2.0.6.6 | Fix issue #169 - Fixed find_event_pipeline IndexError crash |
 | 2.0.6.5 | Fix issue #167 - log support for unattended testing on data centre compute nodes |
 | 2.0.6.4 | Fix issue #164 - progress bar in dask partitioning should be OFF by default |

--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ from setuptools import setup, find_packages
 import numpy
 from setuptools.extension import Extension
 
-__version__ = "2.0.6.6"
+__version__ = "2.0.6.7"
 
 with open("README.md", "r") as fh:
     long_description = fh.read()

--- a/turbo_seti/find_doppler/find_doppler.py
+++ b/turbo_seti/find_doppler/find_doppler.py
@@ -1,29 +1,43 @@
-#!/usr/bin/env python
+"""
+Class FindDoppler
 
+Non-object functions:
+    search_coarse_channel
+    populate_tree
+    hitsearch
+    tophitsearch
+"""
 import os
 import time
 import logging
+logger_name = 'find_doppler'
+logger = logging.getLogger(logger_name)
 
 # Parallel python support
 import dask.bag as db
 from dask.diagnostics import ProgressBar
 
-from .kernels import Kernels, Scheduler
+import numpy as np
+
+#For importing cython code
+import pyximport
+pyximport.install(setup_args={"include_dirs":np.get_include()}, reload_support=True)
+
 from .data_handler import DATAHandle, DATAH5
 from .file_writers import FileWriter, LogWriter
-from .helper_functions import chan_freq, comp_stats
+from .helper_functions import bitrev, chan_freq, comp_stats, FlipX
 from .merge_dats_logs import merge_dats_logs
+
+try:
+    from . import taylor_tree as tt
+except:
+    import taylor_tree as tt
 
 #For debugging
 #import pdb;# pdb.set_trace()
-logger_name = 'find_doppler'
-logger = logging.getLogger(logger_name)
 
 class max_vals:
-    r"""
-    Class used to initialize some maximums.
-
-    """
+    """ Class used to initialize some maximums """
     def __init__(self):
         self.maxsnr = None
         self.maxdrift = None
@@ -32,91 +46,66 @@ class max_vals:
         self.total_n_hits = None
 
 
+class hist_vals:
+    """Temporary class that saved the normalized spectrum for all drift rates."""
+    def __init__(self):
+        self.histsnr = None
+        self.histdrift = None
+        self.histid = None
+
+
 class FindDoppler:
-    r"""
-    Initializes FindDoppler object.
-
-    Parameters
-    ----------
-    datafile : string
-        Inputted filename (.h5 or .fil)
-    max_drift : float
-        Max drift rate in Hz/second.
-    min_drift : int
-        Min drift rate in Hz/second.
-    snr : float
-        Signal to Noise Ratio - A ratio bigger than 1 to 1 has more signal than noise.
-    out_dir : string
-        Directory where output files should be placed. By default this is the
-        current working directory.
-    coarse_chans : list(int)
-        The inputted comma separated list of coarse channels to analyze, if any.
-    obs_info : dict
-        Used to hold info found on file, including info about pulsars, RFI, and SEFD.
-    flagging : bool
-        Flags the edges of the PFF for BL data (with 3Hz res per channel).
-    n_coarse_chan : int
-        Number of coarse channels in file.
-    kernels : Kernels, optional
-        Pre-configured class of Kernels.
-    gpu_backend : bool, optional
-        Use GPU accelerated Kernels.
-    precision : int {2: float64, 1: float32}, optional
-        Floating point precision.
-    append_output : bool, optional
-        Append output DAT & LOG files? (True/False)
-    log_level_int : int, optional
-        Python logging threshold level (INFO, DEBUG, or WARNING)
-
-    """
+    """ """
     def __init__(self, datafile, max_drift, min_drift=0, snr=25.0, out_dir='./', coarse_chans=None,
-                 obs_info=None, flagging=False, n_coarse_chan=None, kernels=None, gpu_backend=False,
-                 precision=2, append_output=False, log_level_int=logging.INFO):
-        if not kernels:
-            self.kernels = Kernels(gpu_backend, precision)
-        else:
-            self.kernels = kernels
+                 obs_info=None, flagging=None, n_coarse_chan=None, log_level_int=logging.INFO):
+        """
+        Initializes FindDoppler object
 
+        Args:
+            datafile (string):  Inputted filename (.h5 or .fil)
+            max_drift (float):  Max drift rate in Hz/second
+            min_drift (int):    Min drift rate in Hz/second
+            snr (float):        Signal to Noise Ratio - A ratio bigger than 1 to 1 has more signal than  noise
+            out_dir (string):   Directory where output files should be placed. By default this is the
+                                current working directory.
+            coarse_chans (list(int)):  the inputted comma separated list of coarse channels to analyze, if any.
+            obs_info (dict):     Used to hold info found on file, including info about pulsars, RFI, and SEFD
+            flagging (bool):     Flags the edges of the PFF for BL data (with 3Hz res per channel)
+            n_coarse_chan (int): Number of coarse channels in file
+        """
         logger.setLevel(log_level_int)
-        self.log_level_int = log_level_int
-
+        
         self.min_drift = min_drift
         self.max_drift = max_drift
-        self.out_dir = out_dir
         self.snr = snr
+        self.out_dir = out_dir
 
-        self.data_handle = DATAHandle(datafile,
-                                      out_dir=out_dir,
-                                      n_coarse_chan=n_coarse_chan,
-                                      coarse_chans=coarse_chans,
-                                      kernels=self.kernels)
+        self.data_handle = DATAHandle(datafile, out_dir=out_dir, n_coarse_chan=n_coarse_chan, coarse_chans=coarse_chans)
         if (self.data_handle is None) or (self.data_handle.status is False):
             raise IOError("File error, aborting...")
 
         if obs_info is None:
             obs_info = {'pulsar': 0, 'pulsar_found': 0, 'pulsar_dm': 0.0, 'pulsar_snr': 0.0,
-                        'pulsar_stats': self.kernels.np.zeros(6), 'RFI_level': 0.0, 'Mean_SEFD': 0.0, 'psrflux_Sens': 0.0,
+                        'pulsar_stats': np.zeros(6), 'RFI_level': 0.0, 'Mean_SEFD': 0.0, 'psrflux_Sens': 0.0,
                         'SEFDs_val': [0.0], 'SEFDs_freq': [0.0], 'SEFDs_freq_up': [0.0]}
 
         self.obs_info = obs_info
 
         self.status = True
         self.flagging = flagging
-        self.append_output = append_output
         self.parms = 'datafile={}, max_drift={}, min_drift={}, snr={}, out_dir={}, coarse_chans={}' \
                         .format(datafile, max_drift, min_drift, snr, out_dir, coarse_chans) \
-                    + ', flagging={}, n_coarse_chan={}, kernels={}, gpu_backend={}' \
-                        .format(flagging, n_coarse_chan, kernels, gpu_backend) \
-                    + ', precision={}, append_output={}, log_level_int={}, obs_info={}' \
-                        .format(precision, append_output, log_level_int, obs_info)
+                    + ', flagging={}, n_coarse_chan={}' \
+                        .format(flagging, n_coarse_chan) \
+                    + ', append_output={}, obs_info={}' \
+                        .format(log_level_int, obs_info)
         print('FindDoppler Parameters: ' + self.parms)
         logger.info(self.data_handle.get_info())
-        print("Start ET search for %s" % datafile)
-
 
     def get_info(self):
-        r"""
-        Generate info string.
+        """Generate info string
+
+        Args: None
 
         Returns:
           : String that contains the values of this FinDoppler object's attributes.
@@ -124,7 +113,6 @@ class FindDoppler:
         """
         info_str = "File: %s\n drift rates (min, max): (%f, %f)\n SNR: %f\n"%(self.data_handle.filename, self.min_drift, self.max_drift, self.snr)
         return info_str
-
 
     def last_logwriter(self, arg_path, arg_text):
         r'''
@@ -146,23 +134,16 @@ class FindDoppler:
 
 
     def search(self, n_partitions=1, progress_bar='n'):
-        r"""
-        Top level search routine.
+        """ Top level search routine
 
-        Parameters
-        ----------
-        n_partitions : int
-            Number of Dask threads to use in parallel. Defaults to single-thread.
-        progress_bar : str {'y', 'n'}, optional
-            Enable command-line progress bar.
+        Uses dask to launch multiple drift searches in parallel
 
-        Notes
-        -----
-        Can use dask to launch multiple drift searches in parallel.
-
+        Args:
+            n_partitions (int): Number of threads to use in parallel. Defaults to 1 (single-threaded)
         """
         t0 = time.time()
-        logger.info(self.get_info())
+        logger.debug("Start searching...")
+        logger.debug(self.get_info())
 
         filename_in = self.data_handle.filename
         header_in   = self.data_handle.header
@@ -170,14 +151,10 @@ class FindDoppler:
         wfilename = filename_in.split('/')[-1].replace('.h5', '').replace('.fits', '').replace('.fil', '')
         path_log = '{}/{}.log'.format(self.out_dir.rstrip('/'), wfilename)
         path_dat = '{}/{}.dat'.format(self.out_dir.rstrip('/'), wfilename)
-        if self.append_output:
-            logger.debug('Appending DAT and LOG files')
-        else:
-            logger.debug('Recreating DAT and LOG files')
-            if os.path.exists(path_log):
-                os.remove(path_log)
-            if os.path.exists(path_dat):
-                os.remove(path_dat)
+        if os.path.exists(path_log):
+            os.remove(path_log)
+        if os.path.exists(path_dat):
+            os.remove(path_dat)
         logwriter = LogWriter(path_log)
         filewriter = FileWriter(path_dat, header_in)
 
@@ -186,9 +163,8 @@ class FindDoppler:
 
         # Run serial version
         if n_partitions == 1:
-            sched = Scheduler(load_data, [ (l, self.kernels) for l in self.data_handle.data_list ])
-            for dl in self.data_handle.data_list:
-                search_coarse_channel(dl, self, dataloader=sched, filewriter=filewriter, logwriter=logwriter)
+            for ii, data_dict in enumerate(self.data_handle.data_list):
+                search_coarse_channel(data_dict, self, filewriter=filewriter, logwriter=logwriter)
         # Run Parallel version via dask
         else:
             print("FindDoppler.search: Using {} dask partitions".format(n_partitions))
@@ -204,43 +180,22 @@ class FindDoppler:
         t1 = time.time()
         self.last_logwriter(path_log, '\n===== Search time: {:.2f} minutes'.format((t1 - t0)/60.0))
 
-def load_data(d, kernel):
-    data_obj = DATAH5(d['filename'], f_start=d['f_start'], f_stop=d['f_stop'],
-                      coarse_chan=d['coarse_chan'], n_coarse_chan=d['n_coarse_chan'], kernels=kernel)
-    spectra, drift_indices = data_obj.load_data()
-    data_obj.close()
 
-    return (data_obj, spectra, drift_indices)
+def search_coarse_channel(data_dict, find_doppler_instance, logwriter=None, filewriter=None):
+    """ Run a turboseti search on a single coarse channel.
 
-def search_coarse_channel(data_dict, find_doppler_instance, dataloader=None, logwriter=None, filewriter=None):
-    r"""
-    Run a turboseti search on a single coarse channel.
-
-    Parameters
-    ----------
-    data_dict : dict
-        File's waterfall data handler.
-        Required keys: {'filename','f_start', 'f_stop', 'coarse_chan', 'n_coarse_chan'}
-    find_doppler_instance : FindDoppler
-        Instance of FindDoppler class.
-    logwriter : LogWriter, optional
-        A LogWriter to write log output into. If None, one will be created.
-    filewriter : FileWriter, optional
-        A FileWriter to use to write the dat file. If None, one will be created.
-
-    Returns
-    -------
-    : bool
-        Returns True if successful (needed for dask).
-
-    Notes
-    -----
     This function is separate from the FindDoppler class to allow parallelization. This should not be called
     directly, but rather via the `FindDoppler.search()` or `FindDoppler.search_dask()` routines.
 
+    Args:
+        data_dict (dict): File's waterfall data handler.
+                        Required keys: {'filename','f_start', 'f_stop', 'coarse_chan', 'n_coarse_chan'}
+        find_doppler_instance (FindDoppler): Instance of FindDoppler class (needed to access search params)
+        logwriter (LogWriter): A LogWriter to write log output into. If None, one will be created.
+        filewriter (FileWriter): A FileWriter to use to write the dat file. If None, one will be created.
+    Returns:
+        Success (bool): Returns True if successful (needed for dask).
     """
-    global logger
-
     d = data_dict
     fd = find_doppler_instance
 
@@ -254,20 +209,17 @@ def search_coarse_channel(data_dict, find_doppler_instance, dataloader=None, log
     flagging = fd.flagging
     coarse_channel = d['coarse_chan']
     logger = logging.getLogger(logger_name + '.' + str(coarse_channel))
-    logger.setLevel(fd.log_level_int)
 
-    if dataloader:
-        data_obj, spectra, drift_indices = dataloader.get()
-    else:
-        data_obj, spectra, drift_indices = load_data(d, fd.kernels)
+    data_obj = DATAH5(d['filename'], f_start=d['f_start'], f_stop=d['f_stop'],
+                      coarse_chan=d['coarse_chan'], n_coarse_chan=d['n_coarse_chan'])
 
     fileroot_out = filename_in.split('/')[-1].replace('.h5', '').replace('.fits', '').replace('.fil', '')
     if logwriter is None:
-        logwriter = LogWriter('%s/%s_%i.log' % (out_dir.rstrip('/'), fileroot_out, coarse_channel))
+        logwriter = LogWriter('%s/%s_%i.log' % (out_dir.rstrip('/'), fileroot_out, d['coarse_chan']))
     if filewriter is None:
-        filewriter = FileWriter('%s/%s_%i.dat' % (out_dir.rstrip('/'), fileroot_out, coarse_channel), header_in)
+        filewriter = FileWriter('%s/%s_%i.dat' % (out_dir.rstrip('/'), fileroot_out, d['coarse_chan']), header_in)
 
-    spectra_flipped = fd.kernels.xp.copy(spectra)[:, ::-1]
+    spectra, drift_indices = data_obj.load_data()
     tsteps = data_obj.tsteps
     tsteps_valid = data_obj.tsteps_valid
     tdwidth = data_obj.tdwidth
@@ -277,60 +229,61 @@ def search_coarse_channel(data_dict, find_doppler_instance, dataloader=None, log
 
     logger.debug('===== coarse_channel={}, f_start={}, f_stop={}'
                 .format(coarse_channel, d['f_start'], d['f_stop']))
-    logger.debug('flagging={}, spectra_flipped={}, tsteps={}, tsteps_valid={}, tdwidth={}, fftlen={}, nframes={}, shoulder_size={}'
-                 .format(flagging, spectra_flipped, tsteps, tsteps_valid, tdwidth, fftlen, nframes, shoulder_size))
+    logger.debug('flagging={}, tsteps={}, tsteps_valid={}, tdwidth={}, fftlen={}, nframes={}, shoulder_size={}'
+                 .format(flagging, tsteps, tsteps_valid, tdwidth, fftlen, nframes, shoulder_size))
 
     if flagging:
         ##EE This flags the edges of the PFF for BL data (with 3Hz res per channel).
         ##EE The PFF flat profile falls after around 100k channels.
         ##EE But it falls slowly enough that could use 50-80k channels.
-        median_flag = fd.kernels.xp.median(spectra)
+        median_flag = np.median(spectra)
         #             spectra[:,:80000] = median_flag/float(tsteps)
         #             spectra[:,-80000:] = median_flag/float(tsteps)
 
         ##EE Flagging spikes in time series.
         time_series = spectra.sum(axis=1)
-        time_series_median = fd.kernels.xp.median(time_series)
+        time_series_median = np.median(time_series)
 
         # Flagging spikes > 10 in SNR
         mask = (time_series - time_series_median) / time_series.std() > 10
         if mask.any():
             logwriter.info("Found spikes in the time series. Removing ...")
-            # So that the value is not the median in the time_series.
-            spectra[mask, :] = time_series_median / float(fftlen)
+            spectra[mask, :] = time_series_median / float(
+                fftlen)  # So that the value is not the median in the time_series.
 
     else:
-        median_flag = fd.kernels.xp.array([0], dtype=fd.kernels.float_type)
+        median_flag = np.array([0])
     logger.debug('median_flag={}'.format(median_flag))
 
     # allocate array for findopplering
     # init findopplering array to zero
-    tree_findoppler = fd.kernels.xp.zeros(tsteps * tdwidth, dtype=fd.kernels.float_type) + median_flag
+    tree_findoppler = np.zeros(tsteps * tdwidth, dtype=np.float64) + median_flag
 
     # allocate array for holding original
     # Allocates array in a fast way (without initialize)
-    tree_findoppler_original = fd.kernels.xp.empty_like(tree_findoppler, dtype=fd.kernels.float_type)
+    tree_findoppler_original = np.empty_like(tree_findoppler)
 
-    hitsearch_buf = fd.kernels.xp.empty(tdwidth, dtype=fd.kernels.float_type)
+    # allocate array for negative doppler rates
+    tree_findoppler_flip = np.empty_like(tree_findoppler)
 
     # build index mask for in-place tree doppler correction
-    ibrev = fd.kernels.xp.zeros(tsteps, dtype=fd.kernels.xp.int32)
+    ibrev = np.zeros(tsteps, dtype=np.int32)
 
     for i in range(0, tsteps):
-        ibrev[i] = fd.kernels.bitrev(i, int(fd.kernels.np.log2(tsteps)))
+        ibrev[i] = bitrev(i, int(np.log2(tsteps)))
 
     ##EE: should double check if tdwidth is really better than fftlen here.
     max_val = max_vals()
     if max_val.maxsnr is None:
-        max_val.maxsnr = fd.kernels.xp.zeros(tdwidth, dtype=fd.kernels.float_type)
+        max_val.maxsnr = np.zeros(tdwidth, dtype=np.float64)
     if max_val.maxdrift is None:
-        max_val.maxdrift = fd.kernels.xp.zeros(tdwidth, dtype=fd.kernels.float_type)
+        max_val.maxdrift = np.zeros(tdwidth, dtype=np.float64)
     if max_val.maxsmooth is None:
-        max_val.maxsmooth = fd.kernels.xp.zeros(tdwidth, dtype=fd.kernels.xp.uint8)
+        max_val.maxsmooth = np.zeros(tdwidth, dtype='uint8')
     if max_val.maxid is None:
-        max_val.maxid = fd.kernels.xp.zeros(tdwidth, dtype=fd.kernels.xp.uint32)
+        max_val.maxid = np.zeros(tdwidth, dtype='uint32')
     if max_val.total_n_hits is None:
-        max_val.total_n_hits = fd.kernels.xp.zeros(1, dtype=fd.kernels.xp.uint32)
+        max_val.total_n_hits = 0
 
     # EE: Making "shoulders" to avoid "edge effects". Could do further testing.
     specstart = int(tsteps * shoulder_size / 2)
@@ -339,253 +292,238 @@ def search_coarse_channel(data_dict, find_doppler_instance, dataloader=None, log
 
     # --------------------------------
     # Stats calc
-    the_mean_val, the_stddev = comp_stats(spectra.sum(axis=0), xp=fd.kernels.xp)
+    the_mean_val, the_stddev = comp_stats(spectra.sum(axis=0))
     logger.debug('comp_stats the_mean_val={}, the_stddev={}'.format(the_mean_val, the_stddev))
 
     # --------------------------------
     # Looping over drift_rate_nblock
     # --------------------------------
-    drift_rate_nblock = int(fd.kernels.xp.floor(max_drift / (data_obj.drift_rate_resolution * tsteps_valid)))
+    drift_rate_nblock = int(np.floor(max_drift / (data_obj.drift_rate_resolution * tsteps_valid)))
     logger.debug('BEGIN looping over drift_rate_nblock, drift_rate_nblock={}.'.format(drift_rate_nblock))
 
     ##EE-debuging        kk = 0
-    drift_low = -1 * drift_rate_nblock
-    drift_high = drift_rate_nblock + 1
-    for drift_block in range(drift_low, drift_high):
-        logger.debug("Drift_block {} (in range from {} through {})"
-                     .format(drift_block, drift_low, drift_rate_nblock))
 
+    for drift_block in range(-1 * drift_rate_nblock, drift_rate_nblock + 1):
+        logger.debug("Drift_block %i" % drift_block)
+
+        # ----------------------------------------------------------------------
+        # Negative drift rates search.
+        # ----------------------------------------------------------------------
         if drift_block <= 0:
-            populate_tree(fd, spectra_flipped, tree_findoppler, nframes, tdwidth, tsteps, fftlen, shoulder_size,
-                          roll=drift_block, reverse=0)
-        else:
-            populate_tree(fd, spectra, tree_findoppler, nframes, tdwidth, tsteps, fftlen, shoulder_size,
+
+            # Populates the find_doppler tree with the spectra
+            populate_tree(spectra, tree_findoppler, nframes, tdwidth, tsteps, fftlen, shoulder_size,
                           roll=drift_block, reverse=1)
 
-        if drift_block == drift_rate_nblock:
-            fd.kernels.xp.copyto(tree_findoppler_original, tree_findoppler)
-        fd.kernels.tt.flt(tree_findoppler, tsteps * tdwidth, tsteps)
+            # populate original array
+            np.copyto(tree_findoppler_original, tree_findoppler)
 
-        if drift_block <= 0:
-            tree_findoppler = tree_findoppler[::-1]
-            logger.debug("Un-flipped corrected negative drift_block")
+            # populate neg doppler array
+            np.copyto(tree_findoppler_flip, tree_findoppler_original)
 
-        tree_findoppler -= the_mean_val
-        tree_findoppler /= the_stddev
+            # Flip matrix across X dimension to search negative doppler drift rates
+            FlipX(tree_findoppler_flip, tdwidth, tsteps)
+            tt.taylor_flt(tree_findoppler_flip, tsteps * tdwidth, tsteps)
+            logger.debug("done...")
 
-        #=========== beginning of eye chart code ===
-        # ***** IMPORTANT: Doing drift block 0 TWICE! to address issue #141. *****
-        if drift_block <= 0:
-            complete_drift_range = data_obj.drift_rate_resolution * fd.kernels.np.array(
-                range(-1 * tsteps_valid * (abs(drift_block) + 1) + 1,
-                      -1 * tsteps_valid * (abs(drift_block)) + 1))
-            sub_range = complete_drift_range[(complete_drift_range < min_drift) &
-                                             (complete_drift_range >= -1 * max_drift)]
-            logger.debug('drift_block <= 0: sub_range={}'.format(sub_range))
-            for k, drift_rate in enumerate(sub_range):
+            complete_drift_range = data_obj.drift_rate_resolution * np.array(
+                range(-1 * tsteps_valid * (np.abs(drift_block) + 1) + 1,
+                      -1 * tsteps_valid * (np.abs(drift_block)) + 1))
+            for k, drift_rate in enumerate(complete_drift_range[(complete_drift_range < min_drift) & (
+                    complete_drift_range >= -1 * max_drift)]):
+                # indx  = ibrev[drift_indices[::-1][k]] * tdwidth
+
                 # DCP 2020.04 -- WAR to drift rate in flipped files
                 if data_obj.header['DELTAF'] < 0:
                     drift_rate *= -1
-    
-                # Grab correct bit of spectrum out of the dedoppler tree output
-                indx = ibrev[drift_indices[k]] * tdwidth
-                fd.kernels.xp.copyto(hitsearch_buf, tree_findoppler[indx: indx + tdwidth])
-                hitsearch(fd, hitsearch_buf, specstart, specend, snr,
-                          drift_rate, data_obj.header, tdwidth, max_val, 0)
 
-        if drift_block >= 0: # Do drift_block number 0 a second time !!!!! (issue #141)
-            complete_drift_range = data_obj.drift_rate_resolution * fd.kernels.np.array(
-                range(tsteps_valid * drift_block,
-                      tsteps_valid * (drift_block + 1)))
-            sub_range = complete_drift_range[(complete_drift_range >= min_drift) &
-                                             (complete_drift_range <= max_drift)]
-            logger.debug('drift_block > 0: sub_range={}'.format(sub_range))
-            for k, drift_rate in enumerate(sub_range):
+                indx = ibrev[drift_indices[::-1][
+                    (complete_drift_range < min_drift)
+                    & (complete_drift_range >= -1 * max_drift)][k]] * tdwidth
+
+                # SEARCH NEGATIVE DRIFT RATES
+                spectrum = tree_findoppler_flip[indx: indx + tdwidth]
+
+                # normalize
+                spectrum -= the_mean_val
+                spectrum /= the_stddev
+
+                # Reverse spectrum back
+                spectrum = spectrum[::-1]
+
+                n_hits, max_val = hitsearch(spectrum, specstart, specend, snr,
+                                            drift_rate, data_obj.header,
+                                            tdwidth, max_val, 0)
+                info_str = "Found %d hits at drift rate %15.15f\n" % (n_hits, drift_rate)
+                max_val.total_n_hits += n_hits
+                logger.debug(info_str)
+
+        # ----------------------------------------------------------------------
+        # Positive drift rates search.
+        # ----------------------------------------------------------------------
+        if drift_block >= 0:
+
+            # Populates the find_doppler tree with the spectra
+            populate_tree(spectra, tree_findoppler, nframes, tdwidth, tsteps, fftlen, shoulder_size,
+                          roll=drift_block, reverse=1)
+
+            # populate original array
+            np.copyto(tree_findoppler_original, tree_findoppler)
+
+            tt.taylor_flt(tree_findoppler, tsteps * tdwidth, tsteps)
+            logger.debug("done...")
+            if (tree_findoppler == tree_findoppler_original).all():
+                logger.error("taylor_flt has no effect?")
+            else:
+                logger.debug("tree_findoppler changed")
+
+            ##EE: Calculates the range of drift rates for a full drift block.
+            complete_drift_range = data_obj.drift_rate_resolution * np.array(
+                range(tsteps_valid * (drift_block), tsteps_valid * (drift_block + 1)))
+
+            for k, drift_rate in enumerate(complete_drift_range[(complete_drift_range >= min_drift)
+                                                                & (complete_drift_range <= max_drift)]):
+
+                indx = ibrev[drift_indices[k]] * tdwidth
+
                 # DCP 2020.04 -- WAR to drift rate in flipped files
                 if data_obj.header['DELTAF'] < 0:
                     drift_rate *= -1
-    
-                # Grab correct bit of spectrum out of the dedoppler tree output
-                indx = ibrev[drift_indices[k]] * tdwidth
-                fd.kernels.xp.copyto(hitsearch_buf, tree_findoppler[indx: indx + tdwidth])
-                hitsearch(fd, hitsearch_buf, specstart, specend, snr,
-                          drift_rate, data_obj.header, tdwidth, max_val, 0)
-        #=========== end of eye chart code =======================================
 
+                # SEARCH POSITIVE DRIFT RATES
+                spectrum = tree_findoppler[indx: indx + tdwidth]
+
+                # normalize
+                spectrum -= the_mean_val
+                spectrum /= the_stddev
+
+                n_hits, max_val = hitsearch(spectrum, specstart, specend, snr, drift_rate, data_obj.header,
+                                            tdwidth, max_val, 0)
+                info_str = "Found %d hits at drift rate %15.15f\n" % (n_hits, drift_rate)
+                max_val.total_n_hits += n_hits
+                logger.debug(info_str)
 
     # Writing the top hits to file.
-    logger.debug('END looping over drift_rate_nblock.')
-    filewriter = tophitsearch(fd, tree_findoppler_original, max_val, tsteps, data_obj.header, tdwidth,
+    filewriter = tophitsearch(tree_findoppler_original, max_val, tsteps, data_obj.header, tdwidth,
                               fftlen, max_drift, data_obj.obs_length,
                               logwriter=logwriter, filewriter=filewriter, obs_info=obs_info)
 
-    logger.debug("Total number of candidates for coarse channel " +
-                str(data_obj.header['coarse_chan']) + " is: %i" % max_val.total_n_hits)
+    logger.debug("Total number of candidates for coarse channel " + str(
+        data_obj.header['coarse_chan']) + " is: %i" % max_val.total_n_hits)
+    data_obj.close()
     filewriter.close()
     logwriter.close()
     return True
 
 
-def populate_tree(fd, spectra, tree_findoppler, nframes, tdwidth, tsteps, fftlen,
+def populate_tree(spectra, tree_findoppler, nframes, tdwidth, tsteps, fftlen,
                   shoulder_size, roll=0, reverse=0):
-    r"""
-    This script populates the findoppler tree with the spectra.
-
-    Parameters
-    ----------
-    fd : FindDoppler
-        Instance of FindDoppler class.
-    spectra : ndarray
-        Spectra calculated from file.
-    tree_findoppler : ndarray
-        Tree to be populated with spectra.
-    nframes : int
-    tdwidth : int
-    tsteps : int
-    fftlen : int
-        Length of fast fourier transform (fft) matrix.
-    shoulder_size : int
-        Size of shoulder region.
-    roll : int, optional
-        Used to calculate amount each entry to the spectra should be rolled (shifted).
-    reverse : int, optional
-        Used to determine which way spectra should be rolled (shifted).
-
-    Returns
-    -------
-    : ndarray
-        Spectra-populated version of the input tree_findoppler.
-
-    Notes
-    -----
+    """This script populates the findoppler tree with the spectra.
     It creates two "shoulders" (each region of tsteps*(shoulder_size/2) in size) to avoid "edge" issues.
     It uses np.roll() for drift-rate blocks higher than 1.
 
+    Args:
+      spectra: ndarray,        spectra calculated from file
+      tree_findoppler: ndarray,        tree to be populated with spectra
+      nframes: int,
+      tdwidth: int,
+      tsteps: int,
+      fftlen: int,            length of fast fourier transform (fft) matrix
+      shoulder_size: int,            size of shoulder region
+      roll: int,            used to calculate amount each entry to the spectra should be rolled (shifted) (Default value = 0)
+      reverse: int(boolean),   used to determine which way spectra should be rolled (shifted) (Default value = 0)
+
+    Returns:
+      : ndarray,        spectra-populated version of the input tree_findoppler
+
     """
+
     if reverse:
         direction = -1
     else:
         direction = 1
 
-    size = tsteps*int(shoulder_size/2)
-
     for i in range(0, nframes):
-        sind_b = (i * tdwidth)
-        sind_a = sind_b + size
+        sind = tdwidth*i + tsteps*int(shoulder_size/2)
+        cplen = fftlen
 
         ##EE copy spectra into tree_findoppler, leaving two regions in each side blanck (each region of tsteps*(shoulder_size/2) in size).
         # Copy spectra into tree_findoppler, with rolling.
-        fd.kernels.xp.copyto(tree_findoppler[sind_a:sind_a+fftlen], fd.kernels.xp.roll(spectra[i], roll * i * direction))
+        np.copyto(tree_findoppler[sind: sind + cplen], np.roll(spectra[i], roll * i * direction))
 
-        ##EE loads the end part of the current spectrum into the left hand side black region in tree_findoppler (comment below says "next spectra" but for that need i+1...bug?)
-        #load end of current spectra into left hand side of next spectra
-        fd.kernels.xp.copyto(tree_findoppler[sind_b:sind_b+size], spectra[i, fftlen-size:fftlen])
+#         ##EE loads the end part of the current spectrum into the left hand side black region in tree_findoppler (comment below says "next spectra" but for that need i+1...bug?)
+         #load end of current spectra into left hand side of next spectra
+        sind = i * tdwidth
+        np.copyto(tree_findoppler[sind: sind + tsteps*int(shoulder_size/2)], spectra[i, fftlen-(tsteps*int(shoulder_size/2)):fftlen])
 
     return tree_findoppler
 
 
-def hitsearch(fd, spectrum, specstart, specend, hitthresh, drift_rate, header, tdwidth, max_val, reverse):
-    r"""
-    Searches for hits at given drift rate. A hit occurs in each channel if > hitthresh.
+def hitsearch(spectrum, specstart, specend, hitthresh, drift_rate, header, tdwidth, max_val, reverse):
+    """Searches for hits at given drift rate. A hit occurs in each channel if > hitthresh.
 
-    Parameters
-    ----------
-    fd : FindDoppler
-        Instance of FindDoppler class.
-    spectrum : ndarray
-    specstart : int
-        First index to search for hit in spectrum.
-    specend : int
-        Last index to search for hit in spectrum.
-    hitthresh : float
-        Signal to noise ratio used as threshold for determining hits.
-    drift_rate : float
-        Drift rate at which we are searching for hits.
-    header : dict
-        Header in fits header format. See data_handler.py's DATAH5 class header.
-    tdwidth : int
-    max_val : max_vals
-        Object to be filled with max values from this search and then returned.
-    reverse : int
-        Used to flag whether fine channel should be reversed.
+    Args:
+      spectrum: ndarray,
+      specstart: int,                first index to search for hit in spectrum
+      specend: int,                last index to search for hit in spectrum
+      hitthresh: float,              signal to noise ratio used as threshold for determining hits
+      drift_rate: float,              drift rate at which we are searching for hits
+      header: dict,               header in fits header format. See data_handler.py's DATAH5 class header
+      tdwidth: int,
+      max_val: max_vals,           object to be filled with max values from this search and then returned
+      reverse: int(boolean),       used to flag whether fine channel should be reversed
+
+    Returns:
+      : int, max_vals,      j is the amount of hits.
 
     """
-    global logger
 
-    logger.debug('Start searching for hits at drift rate: %f' % drift_rate)
+    logger.debug('Start searching for hits at drift rate: %f'%drift_rate)
+    j = 0
+    for i in (spectrum[specstart:specend] > hitthresh).nonzero()[0] + specstart:
+        k = (tdwidth - 1 - i) if reverse else i
+        info_str = 'Hit found at SNR %f! %s\t' % (spectrum[i], '(reverse)' if reverse else '')
+        info_str += 'Spectrum index: %d, Drift rate: %f\t' % (i, drift_rate)
+        info_str += 'Uncorrected frequency: %f\t' % chan_freq(header, k, tdwidth, 0)
+        info_str += 'Corrected frequency: %f' % chan_freq(header, k, tdwidth, 1)
+        logger.debug(info_str)
+        j += 1
+        used_id = j
+        if spectrum[i] > max_val.maxsnr[k]:
+            max_val.maxsnr[k] = spectrum[i]
+            max_val.maxdrift[k] = drift_rate
+            max_val.maxid[k] = used_id
 
-    if fd.kernels.gpu_backend:
+    return j, max_val
 
-        blockSize = 512
-        length = specend - specstart
-        numBlocks = (length + blockSize - 1) // blockSize
-        call = (length, spectrum[specstart:specend], hitthresh, drift_rate,
-                max_val.maxsnr, max_val.maxdrift, max_val.total_n_hits)
-        fd.kernels.hitsearch((numBlocks,), (blockSize,), call)
 
-    else:
-
-        hits = 0
-        for i in (spectrum[specstart:specend] > hitthresh).nonzero()[0] + specstart:
-            k = (tdwidth - 1 - i) if reverse else i
-
-            if logger.level == logging.DEBUG:
-                info_str = 'Hit found at SNR %f! %s\t' % (spectrum[i], '(reverse)' if reverse else '')
-                info_str += 'Spectrum index: %d, Drift rate: %f\t' % (i, drift_rate)
-                info_str += 'Uncorrected frequency: %f\t' % chan_freq(header, k, tdwidth, 0)
-                info_str += 'Corrected frequency: %f' % chan_freq(header, k, tdwidth, 1)
-                logger.debug(info_str)
-
-            hits += 1
-            if spectrum[i] > max_val.maxsnr[k]:
-                max_val.maxsnr[k] = spectrum[i]
-                max_val.maxdrift[k] = drift_rate
-                max_val.maxid[k] = hits
-
-        max_val.total_n_hits[0] += hits
-
-def tophitsearch(fd, tree_findoppler_original, max_val, tsteps, header, tdwidth, fftlen,
+def tophitsearch(tree_findoppler_original, max_val, tsteps, header, tdwidth, fftlen,
                  max_drift, obs_length, logwriter=None, filewriter=None, obs_info=None):
-    r"""
-    This finds the hits with largest SNR within 2*tsteps frequency channels.
+    """This finds the hits with largest SNR within 2*tsteps frequency channels.
 
-    Parameters
-    ----------
-    tree_findoppler_original : ndarray
-        Spectra-populated findoppler tree
-    max_val : max_vals
-        Contains max values from hitsearch
-    tsteps : int
-    header : dict
-        Header in fits header format. Used to report tophit in filewriter.
-        See :class:`~turbo_seti.find_doppler.data_handler.DATAH5`
-    tdwidth : int
-    fftlen : int
-        Length of fast fourier transform (fft) matrix
-    max_drift : float
-        Max drift rate in Hz/second
-    obs_length : float,
-    logwriter : LogWriter, optional
-        Logwriter to which we should write if we find a top hit.
-    filewriter : FileWriter, optional
-        Filewriter corresponding to file to which we should save the local maximum of tophit.
-        See :func:`~turbo_seti.find_doppler.file_writers.FileWriter.report_tophit`
-    obs_info : dict, optional
+    Args:
+      tree_findoppler_original: ndarray,        spectra-populated findoppler tree
+      max_val: max_vals,       contains max values from hitsearch
+      tsteps: int,
+      header: dict,           header in fits header format. See data_handler.py's DATAH5 class header. Used to report tophit in filewriter
+      tdwidth: int,
+      fftlen: int,            length of fast fourier transform (fft) matrix
+      max_drift: float,          Max drift rate in Hz/second
+      obs_length: float,
+      logwriter: LogWriter       logwriter to which we should write if we find a top hit (Default value = None)
+      filewriter: FileWriter      filewriter corresponding to file to which we should save the
+    local maximum of tophit. See report_tophit in filewriters.py (Default value = None)
+      obs_info: dict, (Default value = None)
 
-    Returns
-    -------
-    : FileWriter
-        Same filewriter that was input.
+    Returns:
+      : FileWriter,     same filewriter that was input
 
     """
-    global logger
 
     maxsnr = max_val.maxsnr
-    logger.debug("original matrix size: %d\t(%d, %d)" % (len(tree_findoppler_original), tsteps, tdwidth))
-    logger.debug("tree_orig shape: %s"%str((tsteps, tdwidth)))
-
-    if fd.kernels.gpu_backend:
-        maxsnr = fd.kernels.xp.asnumpy(maxsnr)
+    logger.debug("original matrix size: %d\t(%d, %d)"%(len(tree_findoppler_original), tsteps, tdwidth))
+    tree_orig = tree_findoppler_original.reshape((tsteps, tdwidth))
+    logger.debug("tree_orig shape: %s"%str(tree_orig.shape))
 
     for i in (maxsnr > 0).nonzero()[0]:
         lbound = int(max(0, i - obs_length*max_drift/2))
@@ -604,7 +542,7 @@ def tophitsearch(fd, tree_findoppler_original, max_val, tsteps, header, tdwidth,
             if logwriter:
                 logwriter.info(info_str)
             if filewriter:
-                filewriter = filewriter.report_tophit(max_val, i, (lbound, ubound), tdwidth, fftlen, header,max_val.total_n_hits[0], obs_info=obs_info)
+                filewriter = filewriter.report_tophit(max_val, i, (lbound, ubound), tdwidth, fftlen, header,max_val.total_n_hits, obs_info=obs_info)
             else:
                 logger.error('Not have filewriter? tell me why.')
 


### PR DESCRIPTION
A subrange of drift rates was dropped just as the drift block loop in find_doppler.py transitioned from one formula to another.

Solution: Do drift block number 0 twice, once for each formula being used.

Note that this was the case in previous versions of find_doppler.py (E.g. 1.3.0).