### PR TITLE
Remove numpy dependency from setup.py 

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -8,8 +8,6 @@
 # twine upload dist/*
 
 from setuptools import setup, find_packages
-import numpy
-from setuptools.extension import Extension
 
 __version__ = "2.0.8"
 


### PR DESCRIPTION
Hello,

Currently, numpy is required to install turbo_seti. i.e., it's a build-time dependency, not a run-time dependency. This causes issues when trying to `pip install -r requirements.txt` from a fresh python install. It's currently necessary to first `pip install numpy` before `pip install -r requirements.txt`. Minor issue, but a bit annoying nonetheless. 

It seems that this was introduced in 51ee00e5, which mentions generating cython files. I'm not sure if it's still relevant, but the import doesn't seem to be used in `setup.py`, and the package installs successfully without it. If this is no longer being used, it would be nice to remove it.

Cheers,
Oliver