### PR TITLE
Fix plot_event_pipeline in jupyter notebook

### DIFF
--- a/turbo_seti/find_event/plot_event.py
+++ b/turbo_seti/find_event/plot_event.py
@@ -257,7 +257,7 @@ def make_waterfall_plots(fil_file_list, on_source_name, f_start, f_stop, drift_r
     # show figure before closing if this is an interactive context
     mplbe = matplotlib.get_backend()
     logger_plot_event.debug('make_waterfall_plots: backend = {}'.format(mplbe))
-    if mplbe != 'agg':
+    if mplbe in matplotlib.rcsetup.interactive_bk:
         plt.show()
 
     # close all figure windows

--- a/turbo_seti/find_event/plot_event.py
+++ b/turbo_seti/find_event/plot_event.py
@@ -254,8 +254,13 @@ def make_waterfall_plots(fil_file_list, on_source_name, f_start, f_stop, drift_r
     plt.savefig(path_png, bbox_inches='tight')
     logger_plot_event.debug('make_waterfall_plots: Saved file {}'.format(path_png))
 
-    # show and close all figure windows
-    plt.show()
+    # show figure before closing if this is an interactive context
+    mplbe = matplotlib.get_backend()
+    logger_plot_event.debug('make_waterfall_plots: backend = {}'.format(mplbe))
+    if mplbe != 'agg':
+        plt.show()
+
+    # close all figure windows
     plt.close('all')
 
     return subplots

--- a/turbo_seti/find_event/plot_event.py
+++ b/turbo_seti/find_event/plot_event.py
@@ -254,7 +254,8 @@ def make_waterfall_plots(fil_file_list, on_source_name, f_start, f_stop, drift_r
     plt.savefig(path_png, bbox_inches='tight')
     logger_plot_event.debug('make_waterfall_plots: Saved file {}'.format(path_png))
 
-    # close all figure windows
+    # show and close all figure windows
+    plt.show()
     plt.close('all')
 
     return subplots


### PR DESCRIPTION
Hello,

I was noticing that `plot_event_pipeline` was running successfully and writing `.png` files, but not displaying the plot as output in the notebook. After some digging around, I found commit 67650ad by @texadactyl which addressed #129 by closing the figure created by `make_waterfall_plots` before returning to the caller. It seems that this is why it's not getting rendered in a notebook. 

Simply commenting out `plt.close('all')` at the end of `plot_event` was sufficient to get the plots to render in the notebook again, but I didn't want to revert your  commit and re-open the previous issue, so I kept fiddling. I found that calling `plt.show()` before closing the figure is enough to get it to render in the notebook. 

And, in fact it's even a bit nicer than before, because it renders immediately rather than waiting until the whole cell is finished running, so you get to see plots from `plot_event_pipeline` one at a time as they're ready rather than all at once at the end when all of the plots are ready.

This was just the first solution I came up with - if someone else has a better one, that would be great, too. I'm just trying to help fix some last minute bugs for @elanlavie's tutorial, which is almost ready.

Thanks,
Oliver