### PR TITLE
change min_drift default to 0.00001

### DIFF
--- a/VERSION-HISTORY.md
+++ b/VERSION-HISTORY.md
@@ -5,6 +5,7 @@ This file is a version history of turbo_seti amendments, beginning with version 
 |    Date    | Version | Contents |
 | :--: | :--: | :-- |
 |  **==future==** | **TBD** | Add frequency channel masking capability. See issue #125. |
+| 2021-04-21 | 2.0.19 | Change min_drift default to disallow near-zero drift.
 | 2021-04-13 | 2.0.18 | Add GPU enabled Docker image build.
 | 2021-04-07 | 2.0.17 | Fixed issue #230 - Added turbo_seti/find_event/plot_dat.py which makes a plot similar to the one produced by plot_candidate_events, but also includes the hits detected, in addition to the candidate signal. |
 | 2021-04-03 | 2.0.16 | Fixed issue #225 - Ensure proper order of regression test execution. |

--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@
 
 from setuptools import setup, find_packages
 
-__version__ = "2.0.18"
+__version__ = "2.0.19"
 
 with open("turbo_seti/find_doppler/turbo_seti_version.py", "w") as fh:
     fh.write("TURBO_SETI_VERSION = '{}'\n".format(__version__))
@@ -24,13 +24,10 @@ with open("requirements_test.txt", "r") as fh:
     test_requirements = fh.readlines()
 
 entry_points = {
-    'console_scripts' :
-        ['turboSETI = turbo_seti.find_doppler.seti_event:main']
+    "console_scripts": ["turboSETI = turbo_seti.find_doppler.seti_event:main"]
 }
 
-package_data={
-    'turbo_seti': ['drift_indexes/*.txt', 'find_doppler/kernels/**/*.cu']
-}
+package_data = {"turbo_seti": ["drift_indexes/*.txt", "find_doppler/kernels/**/*.cu"]}
 
 setup(
     name="turbo_seti",
@@ -45,7 +42,7 @@ setup(
     author_email="e.enriquez@berkeley.edu",
     description="Analysis tool for the search of narrow band drifting signals in filterbank data",
     long_description=long_description,
-    long_description_content_type='text/markdown',
+    long_description_content_type="text/markdown",
     license="MIT License",
     keywords="astronomy",
     url="https://github.com/UCBerkeleySETI/turbo_seti",
@@ -56,5 +53,5 @@ setup(
         "Intended Audience :: Science/Research",
         "Programming Language :: Python :: 3",
         "Topic :: Scientific/Engineering",
-        ]
+    ],
 )

--- a/turbo_seti/find_doppler/find_doppler.py
+++ b/turbo_seti/find_doppler/find_doppler.py
@@ -46,7 +46,7 @@ class FindDoppler:
         Inputted filename (.h5 or .fil)
     max_drift : float
         Max drift rate in Hz/second.
-    min_drift : int
+    min_drift : float
         Min drift rate in Hz/second.
     snr : float
         Signal to Noise Ratio - A ratio bigger than 1 to 1 has more signal than noise.
@@ -73,7 +73,7 @@ class FindDoppler:
         Python logging threshold level (INFO, DEBUG, or WARNING)
 
     """
-    def __init__(self, datafile, max_drift=4.0, min_drift=0.0, snr=25.0, out_dir='./', coarse_chans=None,
+    def __init__(self, datafile, max_drift=4.0, min_drift=0.00001, snr=25.0, out_dir='./', coarse_chans=None,
                  obs_info=None, flagging=False, n_coarse_chan=None, kernels=None, gpu_backend=False,
                  precision=2, append_output=False, log_level_int=logging.INFO):
 

--- a/turbo_seti/find_doppler/seti_event.py
+++ b/turbo_seti/find_doppler/seti_event.py
@@ -35,8 +35,8 @@ def main(args=None):
                    help='show the turbo_seti and blimpy versions and exit')
     p.add_argument('-M', '--max_drift', dest='max_drift', type=float, default=10.0,
                    help='Set the maximum drift rate threshold. Unit: Hz/sec. Default: 10.0')
-    p.add_argument('-m', '--min_drift', dest='min_drift', type=float, default=0.0,
-                   help='Set the minimum drift rate threshold. Unit: Hz/sec. Default: 0.0')
+    p.add_argument('-m', '--min_drift', dest='min_drift', type=float, default=0.00001,
+                   help='Set the minimum drift rate threshold. Unit: Hz/sec. Default: 0.00001')
     p.add_argument('-s', '--snr', dest='snr', type=float, default=25.0,
                    help='Set the minimum SNR threshold. Default: 25.0')
     p.add_argument('-o', '--out_dir', dest='out_dir', type=str, default='./',


### PR DESCRIPTION
The current turboseti defaults include signals with zero or near-zero drift, but as per conversation on Slack, these can always be removed because they are artifacts of the DC spike. This PR changes the defaults so that near-zero drifts will be removed by default.