### PR TITLE
find_event_pipeline must diagnose out-of-cadence frequency ranges

### DIFF
--- a/VERSION-HISTORY.md
+++ b/VERSION-HISTORY.md
@@ -4,6 +4,7 @@ This file is a version history of turbo_seti amendments, beginning with version 
 
 | `YYYY_MM_DD` | `Version` | `Contents` |
 | :--: | :--: | :-- |
+| 2021-07-10 | 2.1.2 | Diagnose non-cadence sets of files in find_event_pipeline (issue #250). |
 | 2021-07-09 | 2.1.1 | New turbo_seti utility: plotSETI. |
 | 2021-07-04 | 2.1.0 | The function calc_freq_range uses hardcoded parameter values. These should instead be derived from the data. |
 | | | See issue #231 for the full description and the resolution approach. |

--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@
 
 from setuptools import setup, find_packages
 
-__version__ = "2.1.1"
+__version__ = "2.1.2"
 
 with open("turbo_seti/find_doppler/turbo_seti_version.py", "w") as fh:
     fh.write("TURBO_SETI_VERSION = '{}'\n".format(__version__))


### PR DESCRIPTION
Unrelated files can cause wild indexing errors or memory wipeouts in routines that follow find_event_pipeline().  It is better to catch this situation up front with meaningful diagnosis.