### PR TITLE
Improve CPU utilisation in turbo_seti use of blank_dc function

### DIFF
--- a/VERSION-HISTORY.md
+++ b/VERSION-HISTORY.md
@@ -4,6 +4,7 @@ This file is a version history of turbo_seti amendments, beginning with version 
 
 | `YYYY_MM_DD` | `Version` | `Contents` |
 | :--: | :--: | :-- |
+| 2021-07-18 | 2.1.7 | Create a turbo_seti clone of blank_dc that is optional and uses a different strategy. |
 | 2021-07-15 | 2.1.6 | Calculate normalized value inside hitsearch kernel on GPU-mode. |
 | 2021-07-16 | 2.1.5 | Failed to pass the gpu_id from find_doppler.py to data_handler.py. (issue #254). |
 | 2021-07-15 | 2.1.4 | Add GPU device selection with cli argument gpu_id. (issue #254). |

--- a/VERSION-HISTORY.md
+++ b/VERSION-HISTORY.md
@@ -4,9 +4,9 @@ This file is a version history of turbo_seti amendments, beginning with version 
 
 | `YYYY_MM_DD` | `Version` | `Contents` |
 | :--: | :--: | :-- |
-| 2021-07-18 | 2.1.7 | Create a turbo_seti clone of blank_dc that is optional and uses a different strategy. |
+| 2021-07-18 | 2.1.7 | Create a turbo_seti clone of blank_dc that is optional and uses a different strategy (issue #262). |
 | 2021-07-15 | 2.1.6 | Calculate normalized value inside hitsearch kernel on GPU-mode. |
-| 2021-07-16 | 2.1.5 | Failed to pass the gpu_id from find_doppler.py to data_handler.py. (issue #254). |
+| 2021-07-16 | 2.1.5 | Failed to pass the gpu_id from find_doppler.py to data_handler.py (issue #254). |
 | 2021-07-15 | 2.1.4 | Add GPU device selection with cli argument gpu_id. (issue #254). |
 | 2021-07-15 | 2.1.3 | Diagnose out of range time steps with correct messages (issue #256). |
 | | | Also, stop catching exceptions in seti_event.py which causes a cascade in tracebacks. |

--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@
 
 from setuptools import setup, find_packages
 
-__version__ = "2.1.6"
+__version__ = "2.1.6.42"
 
 with open("turbo_seti/find_doppler/turbo_seti_version.py", "w") as fh:
     fh.write("TURBO_SETI_VERSION = '{}'\n".format(__version__))

--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@
 
 from setuptools import setup, find_packages
 
-__version__ = "2.1.6.42"
+__version__ = "2.1.7"
 
 with open("turbo_seti/find_doppler/turbo_seti_version.py", "w") as fh:
     fh.write("TURBO_SETI_VERSION = '{}'\n".format(__version__))

--- a/test/test_turbo_seti.py
+++ b/test/test_turbo_seti.py
@@ -218,6 +218,14 @@ def test_turboSETI_entry_point():
     h5_5 = os.path.join(TESTDIR, OFFNIL_H5)
     args = [h5_5, "-P", "y", "-s", str(MIN_SNR), "-M", str(MAX_DRIFT), "-o", TESTDIR, ]
     seti_event.main(args)
+    print("\n===== test_turboSETI_entry_point 6 =====")
+    h5_5 = os.path.join(TESTDIR, VOYAH5)
+    args = [h5_5, "--blank_dc", "y", "-s", str(MIN_SNR), "-M", str(MAX_DRIFT), "-o", TESTDIR, ]
+    seti_event.main(args)
+    print("\n===== test_turboSETI_entry_point 7 =====")
+    h5_5 = os.path.join(TESTDIR, VOYAH5)
+    args = [h5_5, "--blank_dc", "n", "-s", str(MIN_SNR), "-M", str(MAX_DRIFT), "-o", TESTDIR, ]
+    seti_event.main(args)
 
 
 def test_make_waterfall_plots():
@@ -350,3 +358,4 @@ def test_flipx_kernel(kernels):
 if __name__ == "__main__":
     print("Please run: pytest test_turbo_seti.py")
     test_find_doppler_voyager()
+    test_turboSETI_entry_point()

--- a/turbo_seti/find_doppler/data_handler.py
+++ b/turbo_seti/find_doppler/data_handler.py
@@ -249,7 +249,7 @@ class DATAH5:
         self.shoulder_size = 0
         self.tdwidth = self.fftlen + self.shoulder_size * self.tsteps
 
-    def load_data(self):
+    def load_data(self, flag_blank_dc=True):
         r"""
         Read the spectra and drift indices from file.
 
@@ -261,11 +261,16 @@ class DATAH5:
         self.fil_file.read_data(f_start=self.f_start, f_stop=self.f_stop)
 
         #Blanking DC bin.
-        if self.n_coarse_chan is not None:
-            n_coarse_chan = self.n_coarse_chan
+        if flag_blank_dc:
+            logger.debug("blank_dc is enabled.")
+            if self.n_coarse_chan is not None:
+                n_coarse_chan = self.n_coarse_chan
+            else:
+                n_coarse_chan = int(self.fil_file.calc_n_coarse_chan())
+            self.fil_file.blank_dc(n_coarse_chan)
         else:
-            n_coarse_chan = int(self.fil_file.calc_n_coarse_chan())
-        self.fil_file.blank_dc(n_coarse_chan)
+            logger.debug("blank_dc is disabled.")
+
 
         dim_time = self.fil_file.data.shape[0]
         if dim_time < 2:

--- a/turbo_seti/find_doppler/data_handler.py
+++ b/turbo_seti/find_doppler/data_handler.py
@@ -11,6 +11,7 @@ import h5py
 from blimpy import Waterfall
 from blimpy.io import sigproc
 
+from .helper_functions import cut_the_mid_spike
 from .kernels import Kernels
 
 logger = logging.getLogger('data_handler')
@@ -267,7 +268,7 @@ class DATAH5:
                 n_coarse_chan = self.n_coarse_chan
             else:
                 n_coarse_chan = int(self.fil_file.calc_n_coarse_chan())
-            self.fil_file.blank_dc(n_coarse_chan)
+            cut_the_mid_spike(self.fil_file.data, n_coarse_chan)
         else:
             logger.debug("blank_dc is disabled.")
 

--- a/turbo_seti/find_doppler/helper_functions.py
+++ b/turbo_seti/find_doppler/helper_functions.py
@@ -1,6 +1,38 @@
 #!/usr/bin/env python
 
 import numpy as np
+import logging
+
+
+def cut_the_mid_spike(data_array, n_coarse_chan):
+    """ Cut the mid-point spike in coarse channels.
+
+    Removes the DC spike in the centre of each coarse channel bin.
+
+    Parameters
+    ----------
+    data_array : ndarray
+        Full data array.
+    n_coarse_chan : int
+        Number of coarse channels.
+    """
+    logger = logging.getLogger('cut_the_mid_spike')
+    if not type(n_coarse_chan) != "int":
+        logger.error("Number of coarse channels is not an integer, no action taken!")
+        return
+    if n_coarse_chan < 1:
+        logger.error = "Number of coarse channels < 1, no action taken!"
+        return
+
+    n_fine_chan = data_array.shape[-1]
+    n_fine_chan_per_coarse_chan = int(n_fine_chan / n_coarse_chan) # ratio of fine channels to coarse channels
+
+    mid_chan = int(n_fine_chan_per_coarse_chan / 2)
+
+    for ii in range(n_coarse_chan):
+        ss = ii * n_fine_chan_per_coarse_chan
+        # Replace the mid point value with the neighbour's value.
+        data_array[..., ss + mid_chan] = data_array[..., ss + mid_chan + 1]
 
 
 def chan_freq(header, fine_channel, tdwidth, ref_frame):

--- a/turbo_seti/find_doppler/seti_event.py
+++ b/turbo_seti/find_doppler/seti_event.py
@@ -54,6 +54,8 @@ def main(args=None):
                    help='Use a progress bar with dask? (y/n)')
     p.add_argument('-g', '--gpu', dest='flag_gpu', type=str, default='n',
                    help='Compute on the GPU? (y/n)')
+    p.add_argument('-z', '--blank_dc', dest='flag_blank_dc', type=str, default='y',
+                   help='Smooth out the DC spike? (y/n)')
     p.add_argument('-d', '--gpu_id', dest='gpu_id', type=int, default=0,
                    help='Use which GPU device? (0,1,...)')
     p.add_argument('-P', '--profile', dest='flag_profile', type=str, default='n',
@@ -132,6 +134,7 @@ def exec_proc(args):
                                   n_coarse_chan=args.n_coarse_chan,
                                   gpu_backend=(args.flag_gpu == "y"),
                                   gpu_id=args.gpu_id,
+                                  blank_dc=(args.flag_blank_dc == "y"),
                                   precision=1 if args.flag_single_precision == "y" else 2,
                                   log_level_int=log_level_int)
 


### PR DESCRIPTION
Create a new helper function to replace using blimpy's Waterfall ```blank_dc``` function: ```cut_the_mid_spike```.

The data_handler.py ```load_data``` function is modified to call it, conditioned on a flag which originates from find_doppler.py ```FindDoppler``` class instantiation.

The seti_event.py main entry point is modified to accept a new command line parameter: ```--blank_dc```.  The value of which is "y" (default) or "n".

This addresses issue #262.