### PR TITLE
Fix #270

### DIFF
--- a/VERSION-HISTORY.md
+++ b/VERSION-HISTORY.md
@@ -4,6 +4,7 @@ This file is a version history of turbo_seti amendments, beginning with version 
 
 | `YYYY_MM_DD` | `Version` | `Contents` |
 | :--: | :--: | :-- |
+| 2021-07-22 | 2.1.11 | Specific MeerKAT files cause erratic behaviour in GPU mode (issue #270). |
 | 2021-07-22 | 2.1.10 | The data_handler crashed during conversion of a 59 GiB filterbank file (issue #267). |
 | 2021-07-22 | 2.1.9 | Performance improvement in gpu mode: default to single-precision (32-bit). |
 | 2021-07-20 | 2.1.8 | Performance improvements and fix min_drift to prevent near-min-drift hits. |

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,6 @@
 from setuptools import setup, find_packages
 
-__version__ = "2.1.10"
+__version__ = "2.1.11"
 
 with open("turbo_seti/find_doppler/turbo_seti_version.py", "w") as fh:
     fh.write("TURBO_SETI_VERSION = '{}'\n".format(__version__))

--- a/turbo_seti/find_doppler/helper_functions.py
+++ b/turbo_seti/find_doppler/helper_functions.py
@@ -123,5 +123,4 @@ def comp_stats(np_arr, xp=None):
     drop_outliers = drop_high[drop_high >= low]
     stdev = drop_outliers.std()
 
-    return median.astype(xp.float32), stdev
-
+    return median.astype(xp.float32), stdev.astype(xp.float32)

--- a/turbo_seti/find_doppler/kernels/_hitsearch/__init__.py
+++ b/turbo_seti/find_doppler/kernels/_hitsearch/__init__.py
@@ -1,4 +1,5 @@
 import os
+import numpy as np
 import cupy as cp
 
 kernels_file = os.path.join(os.path.dirname(__file__), 'kernels.cu')
@@ -21,12 +22,23 @@ def hitsearch(numBlocks, blockSize, call):
         CUDA Kernel number of blocks.
     blockSize : tuple
         CUDA Kernel block size.
-    call : tuple
+    call : [int, ndarray, float, float, ndarray, ndarray, ndarray, float, float]
         Tuple of parameters required by `hitsearch`.
 
     """
 
-    assert isinstance(call[2], float)
+    try:
+        assert isinstance(call[0], int)
+        assert isinstance(call[1], cp._core.core.ndarray)
+        assert isinstance(call[2], float)
+        assert isinstance(call[3], float)
+        assert isinstance(call[4], cp._core.core.ndarray)
+        assert isinstance(call[5], cp._core.core.ndarray)
+        assert isinstance(call[6], cp._core.core.ndarray)
+        assert isinstance(call[7], np.float32)
+        assert isinstance(call[8], np.float32)
+    except:
+        raise ValueError("Check the `call` types of the `hitsearch` method.")
 
     if call[1].dtype == cp.float64:
         _hitsearch_float64(numBlocks, blockSize, call)


### PR DESCRIPTION
This PR fixes issue #270. The `stdev` was returning a `float64` instead of a `float32` expected by the GPU-based `hitsearch` method.