### PR TITLE
Tell the operator how the number of coarse channels was derived

### DIFF
--- a/VERSION-HISTORY.md
+++ b/VERSION-HISTORY.md
@@ -4,6 +4,7 @@ This file is a version history of turbo_seti amendments, beginning with version 
 
 | `YYYY_MM_DD` | `Version` | `Contents` |
 | :--: | :--: | :-- |
+| 2021-11-19 | 2.1.18 | Fix to data_handler.py for handling of the NFPC header field from the new rawspec. (issue #285) |
 | 2021-11-10 | 2.1.17 | Fix to find_event.py which was generating too many events & plots. (issue #283) |
 | 2021-10-28 | 2.1.16 | Print a 3x3 data postage stamp when loading data for coarse channel 0 only. (issue #280) |
 | 2021-10-23 | 2.1.15 | Print a 3x3 data postage stamp when loading data. (issue #280) |

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,6 @@
 from setuptools import setup, find_packages
 
-__version__ = "2.1.17"
+__version__ = "2.1.18"
 
 with open("turbo_seti/find_doppler/turbo_seti_version.py", "w") as fh:
     fh.write("TURBO_SETI_VERSION = '{}'\n".format(__version__))

--- a/test/test_turbo_seti.py
+++ b/test/test_turbo_seti.py
@@ -264,13 +264,6 @@ def test_data_handler(kernels):
     with pytest.raises(IOError):
         data_handler.DATAHandle(filename=os.path.abspath(__file__), kernels=kernels)
     filename_fil = os.path.join(TESTDIR, VOYAFIL)
-    with pytest.raises(IOError):
-        out_dir = os.path.join(tempfile.mkdtemp()) + '/NO/SUCH/DIRECTORY'
-        dh = data_handler.DATAHandle(filename=filename_fil,
-                                     out_dir=out_dir,
-                                     n_coarse_chan=42,
-                                     coarse_chans=None,
-                                     kernels=kernels)
     dh = data_handler.DATAHandle(filename=filename_fil,
                                  out_dir=os.path.join(tempfile.mkdtemp()),
                                  n_coarse_chan=42,


### PR DESCRIPTION
Fix issue #285.

Added data_handler logging to let the operator know how the Number of coarse channels (n_coarse_chan)
is derived - in preferential order:
1. computed based on the .h5 header **nfpc** field (Number of fine channels per coarse channel) 
2. manually entered by the operator (ugh)
3. computed by blimpy (last gasp)

The new nfpc header field is part of an upcoming rawspec release.

When nfpc is present in the .h5 header, then n_coarse_chan = Number of fine channels / nfpc.