### PR TITLE
performance improvement: Use a cupy RawKernel for the GPU Taylor tree inner loop

### DIFF
--- a/VERSION-HISTORY.md
+++ b/VERSION-HISTORY.md
@@ -4,6 +4,7 @@ This file is a version history of turbo_seti amendments, beginning with version 
 
 | `YYYY_MM_DD` | `Version` | `Contents` |
 | :--: | :--: | :-- |
+| 2022-04-04 | 2.2.2 | Performance improvement in GPU mode: Use a cupy RawKernel for the 'flt' function. |
 | 2022-03-30 | 2.2.1 | Expose --plot_offset in plotSETI (issue #305). |
 | | | Fix plot offset output in plot_event.py overlay_drift function  (issue #305). |
 | | | Get rid of Waterfall max_load parameters and object deletes in plot_event.py make_waterfall_plots function. |

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,6 @@
 from setuptools import setup, find_packages
 
-__version__ = "2.2.1"
+__version__ = "2.2.2"
 
 with open("turbo_seti/find_doppler/turbo_seti_version.py", "w") as fh:
     fh.write("TURBO_SETI_VERSION = '{}'\n".format(__version__))
@@ -15,10 +15,11 @@ with open("requirements_test.txt", "r") as fh:
     test_requirements = fh.readlines()
 
 entry_points = {
-    "console_scripts" : [
+    "console_scripts": [
         "turboSETI = turbo_seti.find_doppler.seti_event:main",
         "plotSETI = turbo_seti.find_event.run_pipelines:main",
-        "dat_filter = turbo_seti.find_event.dat_filter:main" ]
+        "dat_filter = turbo_seti.find_event.dat_filter:main",
+    ]
 }
 
 package_data = {"turbo_seti": ["drift_indexes/*.txt", "find_doppler/kernels/**/*.cu"]}

--- a/test/test_turbo_seti.py
+++ b/test/test_turbo_seti.py
@@ -212,7 +212,10 @@ def test_turboSETI_entry_point():
     seti_event.main(args)
     print("\n===== test_turboSETI_entry_point 4 =====")
     h5_4 = os.path.join(TESTDIR, OFFNIL_H5)
-    args = [h5_4, "-g", "y", "-s", str(MIN_SNR), "-M", str(MAX_DRIFT), "-o", TESTDIR, ]
+    args = [h5_4]
+    if Kernels.has_gpu():
+        args.extend(["-g", "y"])
+    args.extend(["-s", str(MIN_SNR), "-M", str(MAX_DRIFT), "-o", TESTDIR, ])
     seti_event.main(args)
     print("\n===== test_turboSETI_entry_point 5 =====")
     h5_5 = os.path.join(TESTDIR, OFFNIL_H5)

--- a/turbo_seti/find_doppler/kernels/__init__.py
+++ b/turbo_seti/find_doppler/kernels/__init__.py
@@ -2,7 +2,8 @@ import importlib
 
 from .Scheduler import Scheduler
 
-class Kernels():
+
+class Kernels:
     r"""
     Dynamically loads the right modules according to parameters.
 
@@ -14,14 +15,14 @@ class Kernels():
         Floating point precision.
 
     """
+
     def __init__(self, gpu_backend=False, precision=2, gpu_id=0):
         self.gpu_backend = gpu_backend
         self.precision = precision
         self.gpu_id = gpu_id
 
         if not self.has_gpu() and self.gpu_backend:
-            print("Warning: Cupy not installed. The GPU will be disabled.")
-            self.gpu_backend = False
+            raise RuntimeError("cupy is not installed, so the GPU cannot be used.")
 
         self._base_lib = "turbo_seti.find_doppler.kernels"
 
@@ -38,7 +39,7 @@ class Kernels():
         if self.precision == 0:
             return self.xp.float16
 
-        raise ValueError('Invalid float precision.')
+        raise ValueError("Invalid float precision.")
 
     def _load_base(self):
         if self.gpu_backend:
@@ -53,16 +54,43 @@ class Kernels():
 
     def _load_taylor_tree(self):
         if self.gpu_backend:
-            self.tt = importlib.import_module(self._base_lib + '._taylor_tree._core_cuda')
+            self.tt = importlib.import_module(
+                self._base_lib + "._taylor_tree._core_cuda"
+            )
         else:
-            self.tt = importlib.import_module(self._base_lib + '._taylor_tree._core_numba')
+            self.tt = importlib.import_module(
+                self._base_lib + "._taylor_tree._core_numba"
+            )
 
     def _load_hitsearch(self):
         if self.gpu_backend:
-            self.hitsearch = importlib.import_module(self._base_lib + '._hitsearch').hitsearch
+            self.hitsearch = importlib.import_module(
+                self._base_lib + "._hitsearch"
+            ).hitsearch
 
     def _load_bitrev(self):
-        self.bitrev = importlib.import_module(self._base_lib + '._bitrev').bitrev
+        self.bitrev = importlib.import_module(self._base_lib + "._bitrev").bitrev
+
+    def get_spectrum(self, tt_output, tsteps, tdwidth, drift_index):
+        """
+        The different Taylor tree kernels have a slightly different output.
+        Both of them you can think of indexed by [row index][frequency], although it is
+        reshaped as a 1-dimensional array.
+        In the GPU version, the row index is the same as the "drift index". 0 is the least drift,
+        1 is the next least drift, et cetera.
+        In the CPU version, the row index is bit-reversed from this.
+        This method lets the caller get data for a particular drift without knowing
+        how the rows are ordered.
+        There's a good chance that one or both of these is suboptimal; please update this
+        comment if you change the underlying algorithm.
+        """
+        if self.gpu_backend:
+            row_index = drift_index
+        else:
+            row_index = self.bitrev(drift_index, int(self.np.log2(tsteps)))
+
+        tt_start_index = row_index * tdwidth
+        return tt_output[tt_start_index : tt_start_index + tdwidth]
 
     @staticmethod
     def has_gpu():
@@ -81,6 +109,7 @@ class Kernels():
         """
         try:
             import cupy
+
             cupy.__version__
         except:
             return False

--- a/turbo_seti/find_doppler/kernels/_taylor_tree/_core_cuda.py
+++ b/turbo_seti/find_doppler/kernels/_taylor_tree/_core_cuda.py
@@ -1,65 +1,82 @@
 import cupy as cp
 import numpy as np
-from numba import jit
 
-from turbo_seti.find_doppler.kernels._bitrev import bitrev
+# Type pairs that we support
+TYPE_PAIRS = {"float": cp.float32, "double": cp.float64}
+
+# Cuda kernels for the flt function to use.
+# It does one round of the Taylor tree algorithm, calculating the sums of length-2^(x+1) paths
+# from the sums of length-2^x paths.
+CODE = r"""
+template<typename T>
+__global__ void taylor(const T* A, T* B, int kmin, int kmax, int set_size, int n_time, int n_freq) {
+  int tid = blockIdx.x * blockDim.x + threadIdx.x;
+  int k = kmin + tid;
+  bool worker = (k >= kmin) && (k < kmax) && set_size <= n_time;
+  if (!worker) {
+    return;
+  }
+  for (int j = 0; j < n_time; j += set_size) {
+    for (int j0 = set_size - 1; j0 >= 0; j0--) {
+      int j1 = j0 / 2;
+      int j2 = j1 + set_size / 2;
+      int j3 = (j0 + 1) / 2;
+      if (k + j3 < kmax) {
+        B[(j + j0) * n_freq + k] = A[(j + j1) * n_freq + k] + A[(j + j2) * n_freq + k + j3];
+      }
+    }
+  }
+}
+"""
+C_TYPES = TYPE_PAIRS.keys()
+NAME_EXPS = [f"taylor<{t}>" for t in C_TYPES]
+MODULE = cp.RawModule(code=CODE, options=("-std=c++11",), name_expressions=NAME_EXPS)
+KERNELS = {}
+for c_type, name_exp in zip(C_TYPES, NAME_EXPS):
+    KERNELS[c_type] = MODULE.get_function(name_exp)
 
 
-def flt(outbuf, mlen, nchn):
-    r"""
-    This is a function to Taylor-tree-sum a data stream. It assumes that
-    the arrangement of data stream is, all points in first spectra, all
-    points in second spectra, etc. Data are summed across time.
- 
-    Parameters
-    ----------
-    outbuf : array_like
-        Input data array, replaced by dedispersed data at the output.
-    mlen : int
-        Dimension of outbuf[].
-    nchn : int
-        Number of frequency channels.
-
-    References
-    ----------
-    - R. Ramachandran, 07-Nov-97, nfra. -- Original algorithm.
-    - A. Siemion, 2011 -- float/64 bit addressing (C-code)
-    - H. Chen, 2014 -- python version
-    - E. Enriquez + P.Schellart, 2016 -- cython version
-    - L. Cruz, 2020 -- vectorized version
-
+def flt(array, n_time):
     """
-    nsamp = (mlen/nchn) - (2*nchn)
-    npts = nsamp + nchn
-    nstages = int(np.log2(nchn))
-    ndat1 = nsamp + 2 * nchn
-    nmem = 1
+    Taylor-tree-sum the data in array.
 
-    for istages in range(0, nstages):
-        nmem  *= 2
-        nsec1  = nchn//nmem
-        nmem2  = nmem - 2
-        
-        for isec in range(0, nsec1):
-            ndelay = -1
-            koff = isec * nmem
-            for ipair in range(0, nmem2+1, 2):
-                ioff1 = int((bitrev(ipair, istages+1) + koff) * ndat1)
-                i2 = int((bitrev(ipair+1, istages+1) + koff) * ndat1)
-                ndelay += 1
-                ndelay2 = (ndelay + 1)
-                nfin = int(npts + ioff1)
+    array should be a 1-dimensional cupy array. If reshaped into two dimensions, the
+    data would be indexed so that array[time][freq] stores the data at a particular time
+    and frequency. So, the same way h5 files are typically stored.
 
-                l1 = (nfin - ioff1)
-                a = outbuf[ioff1:nfin]
-                b = outbuf[i2+ndelay:i2+ndelay+l1]
-                c = outbuf[i2+ndelay2:i2+ndelay2+l1]
+    n_time is the number of timesteps in the data.
 
-                outbuf[ioff1:nfin], outbuf[i2:i2+l1] = sum(a, b, c)
-
-
-@cp.fuse()
-def sum(a, b, c):
+    The algorithm uses one scratch buffer, and in each step of the loop, it calculates
+    sums from one buffer and puts the output in the other. Thus, the drift sums we are looking
+    for may end up either in the original buffer, or in the scratch buffer. This method
+    returns whichever buffer is the one to use, and we leave the other one for cupy to clean up.
     """
-    """
-    return a + b, a + c
+    taylor_kernel = None
+    for c_type, py_type in TYPE_PAIRS.items():
+        if py_type == array.dtype:
+            taylor_kernel = KERNELS[c_type]
+            break
+    else:
+        raise RuntimeError(
+            f"we have no GPU taylor kernel for the numerical type: {array.dtype}"
+        )
+
+    assert len(array) % n_time == 0
+    n_freq = len(array) // n_time
+    buf = cp.zeros_like(array)
+
+    # Cuda params
+    block_size = 1024
+    grid_size = (n_freq + block_size - 1) // block_size
+
+    set_size = 2
+    while set_size <= n_time:
+        taylor_kernel(
+            (grid_size,),
+            (block_size,),
+            (array, buf, 0, n_freq, set_size, n_time, n_freq),
+        )
+        array, buf = buf, array
+        set_size *= 2
+
+    return array

--- a/turbo_seti/find_doppler/kernels/_taylor_tree/_core_numba.py
+++ b/turbo_seti/find_doppler/kernels/_taylor_tree/_core_numba.py
@@ -5,20 +5,18 @@ from turbo_seti.find_doppler.kernels._bitrev import bitrev
 
 
 @jit(nopython=True)
-def flt(outbuf, mlen, nchn):
-    r"""
+def flt(outbuf, nchn):
+    """
     This is a function to Taylor-tree-sum a data stream. It assumes that
     the arrangement of data stream is, all points in first spectra, all
     points in second spectra, etc. Data are summed across time.
- 
+
     Parameters
     ----------
     outbuf : array_like
         Input data array, replaced by dedispersed data at the output.
-    mlen : int
-        Dimension of outbuf[].
     nchn : int
-        Number of frequency channels.
+        Number of timesteps in the data.
 
     References
     ----------
@@ -29,29 +27,32 @@ def flt(outbuf, mlen, nchn):
     - L. Cruz, 2020 -- numba version
 
     """
-    nsamp = (mlen/nchn) - (2*nchn)
+    mlen = len(outbuf)
+    nsamp = (mlen / nchn) - (2 * nchn)
     npts = nsamp + nchn
     nstages = int(np.log2(nchn))
     ndat1 = nsamp + 2 * nchn
     nmem = 1
 
     for istages in range(0, nstages):
-        nmem  *= 2
-        nsec1  = int(nchn/nmem)
-        nmem2  = nmem - 2
-        
+        nmem *= 2
+        nsec1 = int(nchn / nmem)
+        nmem2 = nmem - 2
+
         for isec in range(0, nsec1):
             ndelay = -1
             koff = isec * nmem
-            for ipair in range(0, nmem2+1, 2):
-                ioff1 = int((bitrev(ipair, istages+1) + koff) * ndat1)
-                i2 = int((bitrev(ipair+1, istages+1) + koff) * ndat1)
+            for ipair in range(0, nmem2 + 1, 2):
+                ioff1 = int((bitrev(ipair, istages + 1) + koff) * ndat1)
+                i2 = int((bitrev(ipair + 1, istages + 1) + koff) * ndat1)
                 ndelay += 1
-                ndelay2 = (ndelay + 1)
+                ndelay2 = ndelay + 1
                 nfin = int(npts + ioff1)
 
                 for i1 in range(ioff1, nfin):
-                    itemp = outbuf[i1] + outbuf[i2+ndelay]
-                    outbuf[i2] = outbuf[i1] + outbuf[i2+ndelay2]
+                    itemp = outbuf[i1] + outbuf[i2 + ndelay]
+                    outbuf[i2] = outbuf[i1] + outbuf[i2 + ndelay2]
                     outbuf[i1] = itemp
                     i2 += 1
+
+    return outbuf


### PR DESCRIPTION
This pull request replaces the `flt` function when turboseti is running in GPU mode with a new implementation. Hat tip to @fantonio2 for writing the c+cuda version at https://github.com/UCBerkeleySETI/dedopplerperf/blob/main/CudaTaylor5demo.cu that this is based on. I converted that to a c++ template to handle multiple float types and made some minor tweaks. Then some of the surrounding code is refactored because the CPU implementation of flt stores rows of the output by reversing their bits, and the GPU implementation doesn't, so the format is slightly different.

This speeds up the flt function by a factor of 5x or so, and that was previously around 30% of the time spent by turboseti. Overall this change seems to speed up turboseti by about 15%.

This doesn't change the output of turboseti - the only differences i've noticed are within floating point error. It's purely a performance change.

profiling before this change:
https://bldata.berkeley.edu/pipeline/tmp/turboseti_profile.svg

profiling after this change:
https://bldata.berkeley.edu/pipeline/tmp/new_turboseti_profile.svg