### PR TITLE
fix bug in removing-duplicate-hits logic

### DIFF
--- a/VERSION-HISTORY.md
+++ b/VERSION-HISTORY.md
@@ -4,6 +4,7 @@ This file is a version history of turbo_seti amendments, beginning with version 
 
 | `YYYY_MM_DD` | `Version` | `Contents` |
 | :--: | :--: | :-- |
+| 2022-05-05 | 2.2.4 | Bug fix in the logic for removing duplicate hits. |
 | 2022-05-05 | 2.2.3 | Bug fix in drift rate calculation. |
 | 2022-04-04 | 2.2.2 | Performance improvement in GPU mode: Use a cupy RawKernel for the 'flt' function. |
 | 2022-03-30 | 2.2.1 | Expose --plot_offset in plotSETI (issue #305). |

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,6 @@
 from setuptools import setup, find_packages
 
-__version__ = "2.2.3"
+__version__ = "2.2.4"
 
 with open("turbo_seti/find_doppler/turbo_seti_version.py", "w") as fh:
     fh.write("TURBO_SETI_VERSION = '{}'\n".format(__version__))


### PR DESCRIPTION
The `tophitsearch` code, considers each candidate hit, and checks over a window of frequencies nearby that hit. If there is another larger hit, it doesn't report this one. This is to prevent reporting a single signal as multiple hits.

There was a small bug in this logic. Previously, the index of the edge of the window was calculated as

```
i - obs_length*max_drift/2
```

If you just check the units, `obs_length` is measured in seconds, `max_drift` is measured in Hz/s, so `obs_length * max_drift` has units of Hz, and we were subtracting it from `i` which is a unitless index. So, this is basically just a meaningless calculation.

Also it should be multiplying by 2 instead of adding by 2, because the two signals could be moving toward each other. These two bugs were roughly canceling each other out, so for Green Bank data for example, we were deduplicating over a window of radius 58 when it should have been a window of radius 80. Not too big a difference, and this fix won't change very much in practice, but it's better to be using the right calculation here.